### PR TITLE
Improve a11y and address a few small issues.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "iron-menu-behavior": "polymerelements/iron-menu-behavior#^0.9.0",
     "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^0.9.0",
     "paper-ripple": "polymerelements/paper-ripple#^0.9.0",
+    "paper-styles": "polymerelements/paper-styles#^0.9.0",
     "polymer": "Polymer/polymer#^0.9.0"
   },
   "devDependencies": {

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,8 +25,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <link rel="import" href="../paper-tabs.html">
     <link rel="import" href="../paper-tab.html">
-
-    <style>
+    <style is="custom-style">
+      :root {
+        --paper-toolbar-background: #00bcd4;
+      }
 
       body {
         font-family: sans-serif;

--- a/paper-tab.html
+++ b/paper-tab.html
@@ -25,10 +25,6 @@ Example:
       <paper-tab>TAB 2</paper-tab>
       <paper-tab>TAB 3</paper-tab>
     </paper-tabs>
-
-@group Paper Elements
-@element paper-tab
-@homepage github.io
 -->
 
 <dom-module id="paper-tab">
@@ -67,7 +63,7 @@ Example:
     }
 
     :host(:not(.iron-selected)) > .tab-content {
-      opacity: 0.6;
+      opacity: 0.8;
     }
 
     :host(:focus) .tab-content {
@@ -76,7 +72,7 @@ Example:
     }
 
     #ink {
-      color: #ffff8d;
+      color: var(--paper-tab-ink, --paper-yellow-a100);
       pointer-events: none;
     }
 

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -14,7 +14,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../iron-menu-behavior/iron-menubar-behavior.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="paper-tabs-icons.html">
+<link rel="import" href="paper-tab.html">
 
 <!--
 `paper-tabs` makes it easy to explore and switch between different views or functional aspects of
@@ -66,8 +68,6 @@ Example:
       </paper-tab>
     </paper-tabs>
 
-@group Paper Elements
-@element paper-tabs
 @hero hero.svg
 @demo demo/index.html
 -->
@@ -129,7 +129,7 @@ Example:
       bottom: 0;
       left: 0;
       right: 0;
-      background-color: #ffff8d;
+      background-color: var(--paper-tabs-selection-bar-color, --paper-yellow-a100);
       -webkit-transform-origin: left center;
       transform-origin: left center;
       -webkit-transform: scale(0);


### PR DESCRIPTION
 - Contrast for non-active, non-selected tab text has been increased
   by 20%.
 - Ink color is now controllable with a custom property.
 - `<paper-tab>` is now imported automatically be `<paper-tabs>`

Addresses #17, part of #14 and part of #4.