### PR TITLE
Fix for #31: Re-invoke _tabChanged after attached to dom

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -309,6 +309,10 @@ Custom property | Description | Default
       'iron-select': '_onIronSelect',
       'iron-deselect': '_onIronDeselect'
     },
+    
+    attached: function() { // see PolymerElements/paper-tabs#31
+	  this._tabChanged(this._previousTab, null);
+    },
 
     _computeScrollButtonClass: function(hideThisButton, scrollable, hideScrollButtons) {
       if (!scrollable || hideScrollButtons) {


### PR DESCRIPTION
If the element is not attached to the DOM during the initial `iron-select` event, the position of the selection bar cannot be calculated. This change ensures that the positioning happens when local DOM is rendered.