### PR TITLE
Add type annotation for `selected`

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -264,6 +264,8 @@ Custom property | Description | Default
 
       /**
        * Gets or sets the selected element. The default is to use the index of the item.
+       * 
+       * @type {string|number}
        */
       selected: {
         type: String,


### PR DESCRIPTION
It can actually be either a string or a number (index)