### PR TITLE
Update custom properties

### DIFF
--- a/paper-tab.html
+++ b/paper-tab.html
@@ -13,6 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-behaviors/paper-ripple-behavior.html">
+<link rel="import" href="../paper-styles/default-theme.html">
 
 <!--
 `paper-tab` is styled to look like a tab.  It should be used in conjunction with
@@ -32,7 +33,7 @@ The following custom properties and mixins are available for styling:
 
 Custom property | Description | Default
 ----------------|-------------|----------
-`--paper-tab-ink` | Ink color | `--paper-yellow-a100`
+`--paper-tab-ink` | Ink color | `--accent-color`
 `--paper-tab` | Mixin applied to the tab | `{}`
 `--paper-tab-content` | Mixin applied to the tab content | `{}`
 `--paper-tab-content-unselected` | Mixin applied to the tab content when the tab is not selected | `{}`
@@ -87,7 +88,7 @@ Custom property | Description | Default
       }
 
       paper-ripple {
-        color: var(--paper-tab-ink, --paper-yellow-a100);
+        color: var(--paper-tab-ink, --accent-color);
       }
 
       .tab-content > ::content > a {

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-menu-behavior/iron-menubar-behavior.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../paper-styles/color.html">
+<link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="paper-tabs-icons.html">
 <link rel="import" href="paper-tab.html">
 
@@ -84,7 +84,8 @@ The following custom properties and mixins are available for styling:
 
 Custom property | Description | Default
 ----------------|-------------|----------
-`--paper-tabs-selection-bar-color` | Color for the selection bar | `--paper-yellow-a100`
+`--paper-tabs-background-color` | Color for background | `--default-primary-color`
+`--paper-tabs-selection-bar-color` | Color for the selection bar | `--accent-color`
 `--paper-tabs` | Mixin applied to the tabs | `{}`
 
 @hero hero.svg
@@ -98,6 +99,7 @@ Custom property | Description | Default
         @apply(--layout);
         @apply(--layout-center);
 
+        background-color: var(--paper-tabs-background-color, --default-primary-color);
         height: 48px;
         font-size: 14px;
         font-weight: 500;
@@ -158,7 +160,7 @@ Custom property | Description | Default
         bottom: 0;
         left: 0;
         right: 0;
-        background-color: var(--paper-tabs-selection-bar-color, --paper-yellow-a100);
+        background-color: var(--paper-tabs-selection-bar-color, --accent-color);
           -webkit-transform: scale(0);
         transform: scale(0);
           -webkit-transform-origin: left center;


### PR DESCRIPTION
Why `--paper-yellow-a100`? I think that the `--accent-color` is a better option.

With the PR, we cover all this cases:

This example has:
```css
--dark-primary-color: #00A0B4;
--default-primary-color: #00BCD4;
--accent-color: #FFFF8A;
```

<img src="https://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B6Okdz75tqQsOUdyb0FjQTJTdlk/components_tabs_usage_mobile3.png" width="360">

And this example has:
```css
--dark-primary-color: #757575;
--default-primary-color: #FAFAFA;
--accent-color: #00BCD4;
```

<img src="https://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B6Okdz75tqQsVDk4V2Nnc2U3LTQ/components_tabs_usage_mobile4.png" width="360">

And this example has:
```css
--dark-primary-color: #455A64;
--default-primary-color: #607D8B;
--accent-color: #FDFDFD;
```

<img src="https://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B6Okdz75tqQscExOcHhfYUdNZlE/components_tabs_usage_example1.png" width="360">