### PR TITLE
Fixes #70

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -131,8 +131,10 @@ Custom property | Description | Default
     }
 
     paper-icon-button {
-      width: 24px;
-      padding: 16px;
+      width: 48px;
+      height: 48px;
+      padding: 12px;
+      margin: 0 4px;
     }
 
     #selectionBar {


### PR DESCRIPTION
`paper-icon-button` recently had `box-sizing: border-box` applied, but the css here assumed the default model