### PR TITLE
Fixes #83: Fixes the selection bar movement in RTL.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
-    "iron-menu-behavior": "PolymerElements/iron-menu-behavior#^1.0.0",
+    "iron-menu-behavior": "PolymerElements/iron-menu-behavior#^1.1.0",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
     "paper-behaviors": "PolymerElements/paper-behaviors#^1.0.0",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -483,7 +483,13 @@ Custom property | Description | Default
         // bar animation: expand
         this.$.selectionBar.classList.add('expand');
 
-        if (oldIndex < index) {
+        var moveRight = oldIndex < index;
+        var isRTL = this._isRTL;
+        if (isRTL) {
+          moveRight = !moveRight;
+        }
+
+        if (moveRight) {
           this._positionBar(this._calcPercent(tabRect.left + tabRect.width - oldRect.left, w) - m,
               this._left);
         } else {


### PR DESCRIPTION
The current implementation assumes that changing selection from a higher index tab to a lower index tab implies moving left on the screen (and lower to higher, right).