### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "paper-toolbar": "polymerelements/paper-toolbar#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "iron-pages": "PolymerElements/iron-pages#^1.0.0"
   },
   "ignore": []

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,15 +12,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
   <head>
 
-    <title>paper-tabs</title>
+    <title>paper-tabs demo</title>
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-    <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
-
+    <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
     <link rel="import" href="../../paper-toolbar/paper-toolbar.html">
 
     <link rel="import" href="../paper-tabs.html">
@@ -32,6 +31,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <style is="custom-style" include="paper-tabs-demo-styles"></style>
 
   </head>
+  <style is="custom-style">
+    .link {
+      @apply(--layout-horizontal);
+      @apply(--layout-center-center);
+    }
+    .flex {
+      @apply(--layout-flex);
+    }
+    .self-end {
+      @apply(--layout-self-end);
+    }
+  </style>
   <body unresolved>
 
     <h3>A. No ink effect and no sliding bar</h3>
@@ -118,9 +129,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <paper-tabs selected="0">
 
-      <paper-tab link><a href="#item1" class="horizontal center-center layout">ITEM ONE</a></paper-tab>
-      <paper-tab link><a href="#item2" class="horizontal center-center layout">ITEM TWO</a></paper-tab>
-      <paper-tab link><a href="#item3" class="horizontal center-center layout">ITEM THREE</a></paper-tab>
+      <paper-tab link><a href="#item1" class="link">ITEM ONE</a></paper-tab>
+      <paper-tab link><a href="#item2" class="link">ITEM TWO</a></paper-tab>
+      <paper-tab link><a href="#item3" class="link">ITEM THREE</a></paper-tab>
 
     </paper-tabs>
 

--- a/demo/paper-tabs-demo-styles.html
+++ b/demo/paper-tabs-demo-styles.html
@@ -1,3 +1,13 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
 <dom-module id="paper-tabs-demo-styles">
   <template>
     <style>

--- a/demo/tabs-with-content-example.html
+++ b/demo/tabs-with-content-example.html
@@ -1,8 +1,17 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
 <link rel="import" href="../paper-tabs.html">
 <link rel="import" href="../paper-tab.html">
 
 <link rel="import" href="../../iron-pages/iron-pages.html">
-
 <link rel="import" href="paper-tabs-demo-styles.html">
 
 <dom-module is="tabs-with-content-example">

--- a/paper-tab.html
+++ b/paper-tab.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-behaviors/iron-button-state.html">
@@ -71,7 +70,9 @@ Custom property | Description | Default
       -webkit-transform: translateZ(0);
       transform: translateZ(0);
       transition: opacity 0.1s cubic-bezier(0.4, 0.0, 1, 1);
-
+      @apply(--layout-horizontal);
+      @apply(--layout-center-center);
+      @apply(--layout-flex-auto);
       @apply(--paper-tab-content);
     }
 
@@ -104,7 +105,7 @@ Custom property | Description | Default
 
   <template>
 
-    <div class="tab-content flex-auto center-center horizontal layout">
+    <div class="tab-content">
       <content></content>
     </div>
 

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -10,7 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../iron-menu-behavior/iron-menubar-behavior.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
@@ -58,16 +57,23 @@ To use links in tabs, add `link` attribute to `paper-tab` and put an `<a>`
 element in `paper-tab`.
 
 Example:
+    <style is="custom-style">
+      .link {
+        @apply(--layout-horizontal);
+        @apply(--layout-center-center);
+      }
+    }
+    </style>
 
     <paper-tabs selected="0">
       <paper-tab link>
-        <a href="#link1" class="horizontal center-center layout">TAB ONE</a>
+        <a href="#link1" class="link">TAB ONE</a>
       </paper-tab>
       <paper-tab link>
-        <a href="#link2" class="horizontal center-center layout">TAB TWO</a>
+        <a href="#link2" class="link">TAB TWO</a>
       </paper-tab>
       <paper-tab link>
-        <a href="#link3" class="horizontal center-center layout">TAB THREE</a>
+        <a href="#link3" class="link">TAB THREE</a>
       </paper-tab>
     </paper-tabs>
 
@@ -114,6 +120,7 @@ Custom property | Description | Default
       height: 100%;
       white-space: nowrap;
       overflow: hidden;
+      @apply(--layout-flex);
     }
 
     #tabsContent {
@@ -123,6 +130,10 @@ Custom property | Description | Default
     #tabsContent.scrollable {
       position: absolute;
       white-space: nowrap;
+    }
+
+    #tabsContent.horizontal {
+      @apply(--layout-horizontal);
     }
 
     .hidden {
@@ -183,7 +194,7 @@ Custom property | Description | Default
 
     <paper-icon-button icon="paper-tabs:chevron-left" class$="[[_computeScrollButtonClass(_leftHidden, scrollable, hideScrollButtons)]]" on-up="_onScrollButtonUp" on-down="_onLeftScrollButtonDown" tabindex="-1"></paper-icon-button>
 
-    <div id="tabsContainer" class="flex" on-track="_scroll" on-down="_down">
+    <div id="tabsContainer" on-track="_scroll" on-down="_down">
 
       <div id="tabsContent" class$="[[_computeTabsContentClass(scrollable)]]">
 
@@ -356,7 +367,7 @@ Custom property | Description | Default
     },
 
     _computeTabsContentClass: function(scrollable) {
-      return scrollable ? 'scrollable' : 'horizontal layout';
+      return scrollable ? 'scrollable' : 'horizontal';
     },
 
     _computeSelectionBarClass: function(noBar, alignBottom) {

--- a/test/attr-for-selected.html
+++ b/test/attr-for-selected.html
@@ -18,11 +18,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
     <link rel="import" href="../paper-tabs.html">
-    <link rel="import" href="../../test-fixture/test-fixture.html">
-
+    
   </head>
   <body>
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -18,12 +18,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
     <link rel="import" href="../paper-tabs.html">
     <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
-    <link rel="import" href="../../test-fixture/test-fixture.html">
-
+    
   </head>
   <body>
 


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way