### PR TITLE
Fixes #96 by changing the aria roles of paper-tabs and paper-tab

### DIFF
--- a/paper-tab.html
+++ b/paper-tab.html
@@ -126,7 +126,7 @@ Custom property | Description | Default
     ],
 
     hostAttributes: {
-      role: 'tab'
+      role: 'menuitem'
     },
 
     listeners: {

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -324,7 +324,7 @@ Custom property | Description | Default
     },
 
     hostAttributes: {
-      role: 'tablist'
+      role: 'menu'
     },
 
     listeners: {

--- a/test/basic.html
+++ b/test/basic.html
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <link rel="import" href="../paper-tabs.html">
     <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
-    
+
   </head>
   <body>
 
@@ -98,8 +98,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(tabs.alignBottom, false);
         });
 
-        test('has role tablist', function() {
-          assert.equal(tabs.getAttribute('role'), 'tablist');
+        test('has role menu', function() {
+          assert.equal(tabs.getAttribute('role'), 'menu');
         });
       });
 


### PR DESCRIPTION
Paper-tabs and paper-tab behave as a menu, not a tablist. Change their roles to "menu" and "menuitem".
http://www.w3.org/TR/wai-aria-practices/#menu
http://www.w3.org/TR/wai-aria-practices/#tabpanel