### PR TITLE
Fix docs

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -57,6 +57,7 @@ To use links in tabs, add `link` attribute to `paper-tab` and put an `<a>`
 element in `paper-tab`.
 
 Example:
+
     <style is="custom-style">
       .link {
         @apply(--layout-horizontal);


### PR DESCRIPTION
The empty newline ensures GitHub properly renders the code and the
stuff following it.