### PR TITLE
Fixes #80: Increases the contrast of text / background color in the demos.

### DIFF
--- a/demo/paper-tabs-demo-styles.html
+++ b/demo/paper-tabs-demo-styles.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template>
     <style>
       :root {
-        --paper-toolbar-background: #00bcd4;
+        --paper-toolbar-background: var(--paper-light-blue-800);
       }
 
       body {
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       paper-tabs, paper-toolbar {
-        background-color: #00bcd4;
+        background-color: var(--paper-light-blue-800);
         color: #fff;
         box-shadow: 0px 3px 6px rgba(0, 0, 0, 0.2);
       }
@@ -38,6 +38,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       paper-tabs[align-bottom] {
         box-shadow: 0px -2px 6px rgba(0, 0, 0, 0.15);
+      }
+
+      paper-tabs a {
+        color: #fff;
       }
 
       h3 {


### PR DESCRIPTION
before | after
------ | -----
![screen shot 2015-12-02 at 14 57 29](https://cloud.githubusercontent.com/assets/406614/11546935/117c1578-9905-11e5-950d-eb48d915bcb8.png) | ![screen shot 2015-12-02 at 14 57 43](https://cloud.githubusercontent.com/assets/406614/11546937/1443a17c-9905-11e5-9c62-5bc8bcde74f0.png)
