### PR TITLE
:shell: fix undefined style of selectionBar

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -363,6 +363,8 @@ Custom property | Description | Default
         } else if (alignBottom) {
           return 'align-bottom';
         }
+
+        return '';
       },
 
       // TODO(cdata): Add `track` response back in when gesture lands.


### PR DESCRIPTION
This fixes the `undefined` class via computed binding.

Before fix (there a `undefined` class):
![paper-tabs-undefinedstyle](https://cloud.githubusercontent.com/assets/10607759/11615034/ce712a8c-9c8f-11e5-92a6-9a7bb3393823.png)

After fix (it returns empty string instead of `undefined`):
![fixed-paper-tabs-style](https://cloud.githubusercontent.com/assets/10607759/11615032/be2b8a3c-9c8f-11e5-89d7-97a94226c776.png)