### PR TITLE
Added --paper-tab-ink-opacity to customize ripple opacity

### DIFF
--- a/paper-tab.html
+++ b/paper-tab.html
@@ -33,6 +33,7 @@ The following custom properties and mixins are available for styling:
 Custom property | Description | Default
 ----------------|-------------|----------
 `--paper-tab-ink` | Ink color | `--paper-yellow-a100`
+`--paper-tab-ink-opacity` | Ink color opacity | `0.5`
 `--paper-tab` | Mixin applied to the tab | `{}`
 `--paper-tab-content` | Mixin applied to the tab content | `{}`
 `--paper-tab-content-unselected` | Mixin applied to the tab content when the tab is not selected | `{}`
@@ -87,6 +88,7 @@ Custom property | Description | Default
       }
 
       paper-ripple {
+        opacity: var(--paper-tab-ink-opacity, .5);
         color: var(--paper-tab-ink, --paper-yellow-a100);
       }
 

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -101,11 +101,12 @@ Custom property | Description | Default
         font-size: 14px;
         font-weight: 500;
         overflow: hidden;
-          -moz-user-select: none;
-          -ms-user-select: none;
-          -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        -webkit-user-select: none;
         user-select: none;
         -webkit-tap-highlight-color: rgba(0,0,0,0);
+        -webkit-tap-highlight-color: transparent;
 
         @apply(--paper-tabs);
       }


### PR DESCRIPTION
Added custom property for styling the opacity of the ripple effect.
By having a default value of `0.5` it does not cover the tab content.

With `--paper-tab-ink-opacity`: 
![with-paper-tab-ink-opacity](https://cloud.githubusercontent.com/assets/10607759/12008472/05bd72d6-ac79-11e5-99da-bee662cfab0f.png)

Without `--paper-tab-ink-opacity`: 
![without-paper-tab-ink-opacity](https://cloud.githubusercontent.com/assets/10607759/12008473/05cccf9c-ac79-11e5-8958-3ec48f8c73a0.png)
