### PR TITLE
remove typography import. Use demo-snippet in demo page

### DIFF
--- a/paper-tab.html
+++ b/paper-tab.html
@@ -13,7 +13,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-behaviors/paper-ripple-behavior.html">
-<link rel="import" href="../paper-styles/typography.html">
 
 <!--
 `paper-tab` is styled to look like a tab.  It should be used in conjunction with
@@ -37,6 +36,9 @@ Custom property | Description | Default
 `--paper-tab` | Mixin applied to the tab | `{}`
 `--paper-tab-content` | Mixin applied to the tab content | `{}`
 `--paper-tab-content-unselected` | Mixin applied to the tab content when the tab is not selected | `{}`
+
+This element applies the mixin `--paper-font-common-base` but does not import `paper-styles/typography.html`.
+In order to apply the `Roboto` font to this element, make sure you've imported `paper-styles/typography.html`.
 
 -->
 


### PR DESCRIPTION
As discussed, `typography.html` should be imported in the demo page, and not by the element itself.