### PR TITLE
Fixes #23: Fix fragment link in docs.

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -34,7 +34,7 @@ Example:
       <paper-tab>TAB 3</paper-tab>
     </paper-tabs>
 
-See <a href="#paper-tab">paper-tab</a> for more information about
+See <a href="?active=paper-tab">paper-tab</a> for more information about
 `paper-tab`.
 
 A common usage for `paper-tabs` is to use it along with `iron-pages` to switch


### PR DESCRIPTION
This link does not work when the docs are hosted from a local checkout of the repo (i.e. polyserve) but should work for the catalog.

(Fixes #23)