### PR TITLE
Fixes #135: Add missing semicolon.

### DIFF
--- a/paper-tab.html
+++ b/paper-tab.html
@@ -95,7 +95,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       .tab-content > ::content > a {
-        @apply(--layout-flex-auto)
+        @apply(--layout-flex-auto);
 
         height: 100%;
       }


### PR DESCRIPTION
It's causing the rest of the rules (`height: 100%;`) not to parse, so links wouldn't fill the full height of the tab.