### PR TITLE
Selection bar should beneath content.

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -200,9 +200,9 @@ Custom property | Description | Default
 
     <div id="tabsContainer" on-track="_scroll" on-down="_down">
       <div id="tabsContent" class$="[[_computeTabsContentClass(scrollable)]]">
-        <content select="*"></content>
         <div id="selectionBar" class$="[[_computeSelectionBarClass(noBar, alignBottom)]]"
             on-transitionend="_onBarTransitionEnd"></div>
+        <content select="*"></content>
       </div>
     </div>
 


### PR DESCRIPTION
I have a nav bar where I would like the height of the selected bar to be 100% of the tab. 

I've done so like this:
```
      --paper-tabs-selection-bar: {
        height: 100%;
        background-color: var(--paper-green-700);
        z-index: 0;
      }
```

However, the content is beneath the selection bar. 