### PR TITLE
Fixes #129: Tabs now scroll / show correct arrow buttons for all RTL scrollLeft behaviors.

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -732,29 +732,29 @@ Custom property | Description | Default
       },
 
       /**
-       * Computes (if needed) and returns `__rtlZeroRight`. See below for a
+       * Computes (if needed) and returns `zeroRight`. See below for a
        * description of this value.
        */
       __getRTLZeroRight: function() {
         var __rtlBehavior = this.__rtlBehavior;
-        if (__rtlBehavior.__rtlZeroRight === undefined) {
+        if (__rtlBehavior.zeroRight === undefined) {
           this.__checkRTLBehavior();
         }
 
-        return __rtlBehavior.__rtlZeroRight;
+        return __rtlBehavior.zeroRight;
       },
 
       /**
-       * Computes (if needed) and returns `__rtlPositiveLeft`. See below for a
+       * Computes (if needed) and returns `positiveLeft`. See below for a
        * description of this value.
        */
       __getRTLPositiveLeft: function() {
         var __rtlBehavior = this.__rtlBehavior;
-        if (__rtlBehavior.__rtlPositiveLeft === undefined) {
+        if (__rtlBehavior.positiveLeft === undefined) {
           this.__checkRTLBehavior();
         }
 
-        return __rtlBehavior.__rtlPositiveLeft;
+        return __rtlBehavior.positiveLeft;
       },
 
       // These properties are nested in this object so that the object reference
@@ -767,8 +767,8 @@ Custom property | Description | Default
         // `scrollLeft` is zero when when the left edge of the scrollable area
         // is aligned with the left edge of its overflowing content.)
         // This variable is determined and set in `__checkRTLBehavior` the
-        // first time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
-        __rtlZeroRight: undefined,
+        // first time `zeroRight` or `positiveLeft` is read.
+        zeroRight: undefined,
 
         // True if, when an element has RTL directionality, positive changes
         // to `scrollLeft` cause the scrollable area to show content that is
@@ -776,8 +776,8 @@ Custom property | Description | Default
         // `scrollLeft` cause the scrollable area to show overflowing content
         // that is further to the right.)
         // This variable is determined and set in `__checkRTLBehavior` the
-        // first time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
-        __rtlPositiveLeft: undefined,
+        // first time `zeroRight` or `positiveLeft` is read.
+        positiveLeft: undefined,
       },
 
       /**
@@ -814,7 +814,7 @@ Custom property | Description | Default
         outer.scrollLeft = 0;
         var innerStartRect = inner.getBoundingClientRect();
         var outerStartRect = outer.getBoundingClientRect();
-        __rtlBehavior.__rtlZeroRight = innerStartRect.right === outerStartRect.right;
+        __rtlBehavior.zeroRight = innerStartRect.right === outerStartRect.right;
 
         // Scroll to the end of the scrollable area in the available non-zero
         // direction.
@@ -825,7 +825,7 @@ Custom property | Description | Default
         // overflowing content's bounding box moved have matching signs, then
         // left is the positive direction.
         var contentMovementNegative = innerEndRect.left < innerStartRect.left;
-        __rtlBehavior.__rtlPositiveLeft = fullScrollNegative === contentMovementNegative;
+        __rtlBehavior.positiveLeft = fullScrollNegative === contentMovementNegative;
 
         document.body.removeChild(outer);
       },

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -575,42 +575,14 @@ Custom property | Description | Default
           }, 1);
         },
 
-        _updateScrollButtonsHiddenState: function() {
-          var normalizedLeft =
-            this._scrollLeftToNormalizedLeft(this.$.tabsContainer.scrollLeft);
-
-          this._leftHidden = normalizedLeft <= 0;
-          this._rightHidden = normalizedLeft >= this._tabContainerScrollSize;
-        },
-
         /**
-         * Normalizes a value returned by `scrollLeft`, which can be writing
-         * direction dependent, to its LTR equivalent.
+         * Adjusts `scrollLeft` by a relative amount, with positive values
+         * scrolling into view content hidden to the right (LTR-like),
+         * regardless of the element's current directionality.
          */
-        _scrollLeftToNormalizedLeft: function(scrollLeft) {
-          if (this._getRTL()) {
-            var normalizedLeft = scrollLeft;
-            normalizedLeft *= this.__rtlPositiveLeft ? -1 : 1;
-            normalizedLeft += this.__rtlZeroRight ? this._tabContainerScrollSize : 0;
-            return normalizedLeft;
-          } else {
-            return scrollLeft;
-          }
-        },
-
-        /**
-         * Converts normalized (LTR-like) `scrollLeft` values to the browser
-         * specific value based on the element's current directionality.
-         */
-        _normalizedLeftToScrollLeft: function(normalizedLeft) {
-          if (this._getRTL()) {
-            var scrollLeft = normalizedLeft;
-            scrollLeft -= this.__rtlZeroRight ? this._tabContainerScrollSize : 0;
-            scrollLeft *= this.__rtlPositiveLeft ? -1 : 1;
-            return scrollLeft;
-          } else {
-            return normalizedLeft;
-          }
+        _affectScroll: function(dx) {
+          this.$.tabsContainer.scrollLeft += (this._getRTL() && this.__rtlPositiveLeft ? -1 : 1) * dx;
+          this._updateScrollButtonsHiddenState();
         },
 
         /**
@@ -622,14 +594,12 @@ Custom property | Description | Default
           this._updateScrollButtonsHiddenState();
         },
 
-        /**
-         * Adjusts `scrollLeft` by a relative amount, with positive values
-         * scrolling into view content hidden to the right (LTR-like),
-         * regardless of the element's current directionality.
-         */
-        _affectScroll: function(dx) {
-          this.$.tabsContainer.scrollLeft += (this._getRTL() && this.__rtlPositiveLeft ? -1 : 1) * dx;
-          this._updateScrollButtonsHiddenState();
+        _updateScrollButtonsHiddenState: function() {
+          var normalizedLeft =
+            this._scrollLeftToNormalizedLeft(this.$.tabsContainer.scrollLeft);
+
+          this._leftHidden = normalizedLeft <= 0;
+          this._rightHidden = normalizedLeft >= this._tabContainerScrollSize;
         },
 
         _onLeftScrollButtonDown: function() {
@@ -748,6 +718,36 @@ Custom property | Description | Default
           // bar animation done
           } else if (cl.contains('contract')) {
             cl.remove('contract');
+          }
+        },
+
+        /**
+         * Normalizes a value returned by `scrollLeft`, which can be writing
+         * direction dependent, to its LTR equivalent.
+         */
+        _scrollLeftToNormalizedLeft: function(scrollLeft) {
+          if (this._getRTL()) {
+            var normalizedLeft = scrollLeft;
+            normalizedLeft *= this.__rtlPositiveLeft ? -1 : 1;
+            normalizedLeft += this.__rtlZeroRight ? this._tabContainerScrollSize : 0;
+            return normalizedLeft;
+          } else {
+            return scrollLeft;
+          }
+        },
+
+        /**
+         * Converts normalized (LTR-like) `scrollLeft` values to the browser
+         * specific value based on the element's current directionality.
+         */
+        _normalizedLeftToScrollLeft: function(normalizedLeft) {
+          if (this._getRTL()) {
+            var scrollLeft = normalizedLeft;
+            scrollLeft -= this.__rtlZeroRight ? this._tabContainerScrollSize : 0;
+            scrollLeft *= this.__rtlPositiveLeft ? -1 : 1;
+            return scrollLeft;
+          } else {
+            return normalizedLeft;
           }
         },
 

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -126,26 +126,9 @@ Custom property | Description | Default
         position: relative;
         height: 100%;
         white-space: nowrap;
-        /*
-        Fall back to scrollbars; `overflow` can't be `hidden` because it
-        disables native scrolling.
-        */
-        overflow: scroll;
-        /* Hide scrollbars in Firefox. */
-        overflow: -moz-scrollbars-none;
-        /* Hide scrollbars in Edge and IE. */
-        -ms-overflow-style: none;
-        /* Enable scrolling inertia in mobile Safari. */
-        -webkit-overflow-scrolling: touch;
+        overflow: hidden;
         @apply(--layout-flex-auto);
         @apply(--paper-tabs-container);
-      }
-
-      /* Hide scrollbars in Chrome and Safari. */
-      #tabsContainer::-webkit-scrollbar {
-        width: 0px;
-        height: 0px;
-        background: transparent;
       }
 
       #tabsContent {
@@ -232,7 +215,7 @@ Custom property | Description | Default
 
     <paper-icon-button icon="paper-tabs:chevron-left" class$="[[_computeScrollButtonClass(_leftHidden, scrollable, hideScrollButtons)]]" on-up="_onScrollButtonUp" on-down="_onLeftScrollButtonDown" tabindex="-1"></paper-icon-button>
 
-    <div id="tabsContainer" on-track="_scroll" on-scroll="_onScroll" on-down="_down">
+    <div id="tabsContainer" on-track="_scroll" on-down="_down">
       <div id="tabsContent" class$="[[_computeTabsContentClass(scrollable, fitContainer)]]">
         <div id="selectionBar" class$="[[_computeSelectionBarClass(noBar, alignBottom)]]"
             on-transitionend="_onBarTransitionEnd"></div>
@@ -540,10 +523,6 @@ Custom property | Description | Default
         this._affectScroll(ddx);
       },
 
-      _onScroll: function(e) {
-        this.__updateScrollButtonsHiddenState();
-      },
-
       _down: function(e) {
         // go one beat async to defeat IronMenuBehavior
         // autorefocus-on-no-selection timeout
@@ -611,6 +590,7 @@ Custom property | Description | Default
           this.$.selectionBar.classList.remove('expand');
           this.$.selectionBar.classList.remove('contract');
           this._positionBar(0, 0);
+          this.__updateScrollButtonsHiddenState();
           return;
         }
 

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -370,26 +370,6 @@ Custom property | Description | Default
         'left:keyup right:keyup': '_onArrowKeyup'
       },
 
-      registered: function() {
-        // True if, when an element has RTL directionality, `scrollLeft` is
-        // zero when the right edge of the scrollable area is aligned with the
-        // right edge of its overflowing content. (As opposed to LTR, where
-        // `scrollLeft` is zero when when the left edge of the scrollable area
-        // is aligned with the left edge of its overflowing content.)
-        // This variable is determined and set in `__checkRTLBehavior` the
-        // first time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
-        this.__rtlZeroRight = undefined;
-
-        // True if, when an element has RTL directionality, positive changes
-        // to `scrollLeft` cause the scrollable area to show content that is
-        // further to the left. (As opposed to LTR, where positive changes to
-        // `scrollLeft` cause the scrollable area to show overflowing content
-        // that is further to the right.)
-        // This variable is determined and set in `__checkRTLBehavior` the
-        // first time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
-        this.__rtlPositiveLeft = undefined;
-      },
-
       created: function() {
         this._holdJob = null;
         this._pendingActivationItem = undefined;
@@ -563,7 +543,7 @@ Custom property | Description | Default
         if (scrollFactor !== 0) {
           e.preventDefault();
           this._affectScroll(e.deltaX * scrollFactor);
-          this._updateScrollButtonsHiddenState();
+          this.__updateScrollButtonsHiddenState();
         }
       },
 
@@ -754,24 +734,61 @@ Custom property | Description | Default
         }
       },
 
+      /**
+       * Computes (if needed) and returns `__rtlZeroRight`. See below for a
+       * description of this value.
+       */
       __getRTLZeroRight: function() {
-        if (this.__rtlZeroRight === undefined) {
+        var __rtlBehavior = this.__rtlBehavior;
+        if (__rtlBehavior.__rtlZeroRight === undefined) {
           this.__checkRTLBehavior();
         }
 
-        return this.__rtlZeroRight;
+        return __rtlBehavior.__rtlZeroRight;
       },
 
+      /**
+       * Computes (if needed) and returns `__rtlPositiveLeft`. See below for a
+       * description of this value.
+       */
       __getRTLPositiveLeft: function() {
-        if (this.__rtlPositiveLeft === undefined) {
+        var __rtlBehavior = this.__rtlBehavior;
+        if (__rtlBehavior.__rtlPositiveLeft === undefined) {
           this.__checkRTLBehavior();
         }
 
-        return this.__rtlPositiveLeft;
+        return __rtlBehavior.__rtlPositiveLeft;
       },
 
+      // These properties are nested in this object so that the object reference
+      // is copied to each instance in IE10, where the prototype of an object
+      // can't be changed after it is created.
+      __rtlBehavior: {
+        // True if, when an element has RTL directionality, `scrollLeft` is
+        // zero when the right edge of the scrollable area is aligned with the
+        // right edge of its overflowing content. (As opposed to LTR, where
+        // `scrollLeft` is zero when when the left edge of the scrollable area
+        // is aligned with the left edge of its overflowing content.)
+        // This variable is determined and set in `__checkRTLBehavior` the
+        // first time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
+        __rtlZeroRight: undefined,
+
+        // True if, when an element has RTL directionality, positive changes
+        // to `scrollLeft` cause the scrollable area to show content that is
+        // further to the left. (As opposed to LTR, where positive changes to
+        // `scrollLeft` cause the scrollable area to show overflowing content
+        // that is further to the right.)
+        // This variable is determined and set in `__checkRTLBehavior` the
+        // first time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
+        __rtlPositiveLeft: undefined,
+      },
+
+      /**
+       * Computes the browser's `scrollLeft` behavior for elements with RTL
+       * directionality.
+       */
       __checkRTLBehavior: function() {
-        var prototype = Object.getPrototypeOf(this);
+        var __rtlBehavior = this.__rtlBehavior;
 
         var outer = document.createElement('div');
         outer.setAttribute('dir', 'rtl');
@@ -800,7 +817,7 @@ Custom property | Description | Default
         outer.scrollLeft = 0;
         var innerStartRect = inner.getBoundingClientRect();
         var outerStartRect = outer.getBoundingClientRect();
-        prototype.__rtlZeroRight = innerStartRect.right === outerStartRect.right;
+        __rtlBehavior.__rtlZeroRight = innerStartRect.right === outerStartRect.right;
 
         // Scroll to the end of the scrollable area in the available non-zero
         // direction.
@@ -811,7 +828,7 @@ Custom property | Description | Default
         // overflowing content's bounding box moved have matching signs, then
         // left is the positive direction.
         var contentMovementNegative = innerEndRect.left < innerStartRect.left;
-        prototype.__rtlPositiveLeft = fullScrollNegative === contentMovementNegative;
+        __rtlBehavior.__rtlPositiveLeft = fullScrollNegative === contentMovementNegative;
 
         document.body.removeChild(outer);
       },

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -229,588 +229,592 @@ Custom property | Description | Default
   </template>
 
   <script>
-    (function() {
-      // True if, when an element has RTL directionality, `scrollLeft` is zero
-      // when the right edge of the scrollable area is aligned with the right
-      // edge of its overflowing content.
-      // (As opposed to LTR, where `scrollLeft` is zero when when the left edge
-      // of the scrollable area is aligned with the left edge of its overflowing
-      // content.)
-      // This variable is determined and set in `__checkRTLBehavior` the first
-      // time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
-      var RTL_ZERO_RIGHT = undefined;
+    Polymer({
+      is: 'paper-tabs',
 
-      // True if, when an element has RTL directionality, positive changes to
-      // `scrollLeft` cause the scrollable area to show content that is further
-      // to the left.
-      // (As opposed to LTR, where positive changes to `scrollLeft` cause the
-      // scrollable area to show overflowing content that is further to the
-      // right.)
-      // This variable is determined and set in `__checkRTLBehavior` the first
-      // time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
-      var RTL_POSITIVE_LEFT = undefined;
+      behaviors: [
+        Polymer.IronResizableBehavior,
+        Polymer.IronMenubarBehavior
+      ],
 
-      Polymer({
-        is: 'paper-tabs',
-
-        behaviors: [
-          Polymer.IronResizableBehavior,
-          Polymer.IronMenubarBehavior
-        ],
-
-        properties: {
-          /**
-           * If true, ink ripple effect is disabled. When this property is changed,
-           * all descendant `<paper-tab>` elements have their `noink` property
-           * changed to the new value as well.
-           */
-          noink: {
-            type: Boolean,
-            value: false,
-            observer: '_noinkChanged'
-          },
-
-          /**
-           * If true, the bottom bar to indicate the selected tab will not be shown.
-           */
-          noBar: {
-            type: Boolean,
-            value: false
-          },
-
-          /**
-           * If true, the slide effect for the bottom bar is disabled.
-           */
-          noSlide: {
-            type: Boolean,
-            value: false
-          },
-
-          /**
-           * If true, tabs are scrollable and the tab width is based on the label width.
-           */
-          scrollable: {
-            type: Boolean,
-            value: false
-          },
-
-          /**
-           * If true, tabs expand to fit their container. This currently only applies when
-           * scrollable is true.
-           */
-          fitContainer: {
-            type: Boolean,
-            value: false
-          },
-
-          /**
-           * If true, dragging on the tabs to scroll is disabled.
-           */
-          disableDrag: {
-            type: Boolean,
-            value: false
-          },
-
-          /**
-           * If true, scroll buttons (left/right arrow) will be hidden for scrollable tabs.
-           */
-          hideScrollButtons: {
-            type: Boolean,
-            value: false
-          },
-
-          /**
-           * If true, the tabs are aligned to bottom (the selection bar appears at the top).
-           */
-          alignBottom: {
-            type: Boolean,
-            value: false
-          },
-
-          selectable: {
-            type: String,
-            value: 'paper-tab'
-          },
-
-          /**
-           * If true, tabs are automatically selected when focused using the
-           * keyboard.
-           */
-          autoselect: {
-            type: Boolean,
-            value: false
-          },
-
-          /**
-           * The delay (in milliseconds) between when the user stops interacting
-           * with the tabs through the keyboard and when the focused item is
-           * automatically selected (if `autoselect` is true).
-           */
-          autoselectDelay: {
-            type: Number,
-            value: 0
-          },
-
-          _step: {
-            type: Number,
-            value: 10
-          },
-
-          _holdDelay: {
-            type: Number,
-            value: 1
-          },
-
-          _leftHidden: {
-            type: Boolean,
-            value: false
-          },
-
-          _rightHidden: {
-            type: Boolean,
-            value: false
-          },
-
-          _previousTab: {
-            type: Object
-          }
+      properties: {
+        /**
+         * If true, ink ripple effect is disabled. When this property is changed,
+         * all descendant `<paper-tab>` elements have their `noink` property
+         * changed to the new value as well.
+         */
+        noink: {
+          type: Boolean,
+          value: false,
+          observer: '_noinkChanged'
         },
 
-        hostAttributes: {
-          role: 'tablist'
+        /**
+         * If true, the bottom bar to indicate the selected tab will not be shown.
+         */
+        noBar: {
+          type: Boolean,
+          value: false
         },
 
-        listeners: {
-          'iron-resize': '_onTabSizingChanged',
-          'iron-items-changed': '_onTabSizingChanged',
-          'iron-select': '_onIronSelect',
-          'iron-deselect': '_onIronDeselect'
+        /**
+         * If true, the slide effect for the bottom bar is disabled.
+         */
+        noSlide: {
+          type: Boolean,
+          value: false
         },
 
-        keyBindings: {
-          'left:keyup right:keyup': '_onArrowKeyup'
+        /**
+         * If true, tabs are scrollable and the tab width is based on the label width.
+         */
+        scrollable: {
+          type: Boolean,
+          value: false
         },
 
-        created: function() {
-          this._holdJob = null;
+        /**
+         * If true, tabs expand to fit their container. This currently only applies when
+         * scrollable is true.
+         */
+        fitContainer: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * If true, dragging on the tabs to scroll is disabled.
+         */
+        disableDrag: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * If true, scroll buttons (left/right arrow) will be hidden for scrollable tabs.
+         */
+        hideScrollButtons: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * If true, the tabs are aligned to bottom (the selection bar appears at the top).
+         */
+        alignBottom: {
+          type: Boolean,
+          value: false
+        },
+
+        selectable: {
+          type: String,
+          value: 'paper-tab'
+        },
+
+        /**
+         * If true, tabs are automatically selected when focused using the
+         * keyboard.
+         */
+        autoselect: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * The delay (in milliseconds) between when the user stops interacting
+         * with the tabs through the keyboard and when the focused item is
+         * automatically selected (if `autoselect` is true).
+         */
+        autoselectDelay: {
+          type: Number,
+          value: 0
+        },
+
+        _step: {
+          type: Number,
+          value: 10
+        },
+
+        _holdDelay: {
+          type: Number,
+          value: 1
+        },
+
+        _leftHidden: {
+          type: Boolean,
+          value: false
+        },
+
+        _rightHidden: {
+          type: Boolean,
+          value: false
+        },
+
+        _previousTab: {
+          type: Object
+        }
+      },
+
+      hostAttributes: {
+        role: 'tablist'
+      },
+
+      listeners: {
+        'iron-resize': '_onTabSizingChanged',
+        'iron-items-changed': '_onTabSizingChanged',
+        'iron-select': '_onIronSelect',
+        'iron-deselect': '_onIronDeselect'
+      },
+
+      keyBindings: {
+        'left:keyup right:keyup': '_onArrowKeyup'
+      },
+
+      registered: function() {
+        // True if, when an element has RTL directionality, `scrollLeft` is
+        // zero when the right edge of the scrollable area is aligned with the
+        // right edge of its overflowing content. (As opposed to LTR, where
+        // `scrollLeft` is zero when when the left edge of the scrollable area
+        // is aligned with the left edge of its overflowing content.)
+        // This variable is determined and set in `__checkRTLBehavior` the
+        // first time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
+        this.__rtlZeroRight = undefined;
+
+        // True if, when an element has RTL directionality, positive changes
+        // to `scrollLeft` cause the scrollable area to show content that is
+        // further to the left. (As opposed to LTR, where positive changes to
+        // `scrollLeft` cause the scrollable area to show overflowing content
+        // that is further to the right.)
+        // This variable is determined and set in `__checkRTLBehavior` the
+        // first time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
+        this.__rtlPositiveLeft = undefined;
+      },
+
+      created: function() {
+        this._holdJob = null;
+        this._pendingActivationItem = undefined;
+        this._pendingActivationTimeout = undefined;
+        this._bindDelayedActivationHandler = this._delayedActivationHandler.bind(this);
+        this.addEventListener('blur', this._onBlurCapture.bind(this), true);
+        this.__cachedRTL = undefined;
+      },
+
+      detached: function() {
+        this._cancelPendingActivation();
+      },
+
+      _noinkChanged: function(noink) {
+        var childTabs = Polymer.dom(this).querySelectorAll('paper-tab');
+        childTabs.forEach(noink ? this._setNoinkAttribute : this._removeNoinkAttribute);
+      },
+
+      _setNoinkAttribute: function(element) {
+        element.setAttribute('noink', '');
+      },
+
+      _removeNoinkAttribute: function(element) {
+        element.removeAttribute('noink');
+      },
+
+      _computeScrollButtonClass: function(hideThisButton, scrollable, hideScrollButtons) {
+        if (!scrollable || hideScrollButtons) {
+          return 'hidden';
+        }
+
+        if (hideThisButton) {
+          return 'not-visible';
+        }
+
+        return '';
+      },
+
+      _computeTabsContentClass: function(scrollable, fitContainer) {
+        return scrollable ? 'scrollable' + (fitContainer ? ' fit-container' : '') : ' fit-container';
+      },
+
+      _computeSelectionBarClass: function(noBar, alignBottom) {
+        if (noBar) {
+          return 'hidden';
+        } else if (alignBottom) {
+          return 'align-bottom';
+        }
+
+        return '';
+      },
+
+      // TODO(cdata): Add `track` response back in when gesture lands.
+
+      _onTabSizingChanged: function() {
+        this.debounce('_onTabSizingChanged', function() {
+          this._tabChanged(this.selectedItem);
+        }, 10);
+      },
+
+      _onIronSelect: function(event) {
+        this._tabChanged(event.detail.item, this._previousTab);
+        this._previousTab = event.detail.item;
+        this.cancelDebouncer('tab-changed');
+      },
+
+      _onIronDeselect: function(event) {
+        this.debounce('tab-changed', function() {
+          this._tabChanged(null, this._previousTab);
+          this._previousTab = null;
+        // See polymer/polymer#1305
+        }, 1);
+      },
+
+      _activateHandler: function() {
+        // Cancel item activations scheduled by keyboard events when any other
+        // action causes an item to be activated (e.g. clicks).
+        this._cancelPendingActivation();
+
+        Polymer.IronMenuBehaviorImpl._activateHandler.apply(this, arguments);
+      },
+
+      /**
+       * Activates an item after a delay (in milliseconds).
+       */
+      _scheduleActivation: function(item, delay) {
+        this._pendingActivationItem = item;
+        this._pendingActivationTimeout = this.async(
+            this._bindDelayedActivationHandler, delay);
+      },
+
+      /**
+       * Activates the last item given to `_scheduleActivation`.
+       */
+      _delayedActivationHandler: function() {
+        var item = this._pendingActivationItem;
+        this._pendingActivationItem = undefined;
+        this._pendingActivationTimeout = undefined;
+        item.fire(this.activateEvent, null, {
+          bubbles: true,
+          cancelable: true
+        });
+      },
+
+      /**
+       * Cancels a previously scheduled item activation made with
+       * `_scheduleActivation`.
+       */
+      _cancelPendingActivation: function() {
+        if (this._pendingActivationTimeout !== undefined) {
+          this.cancelAsync(this._pendingActivationTimeout);
           this._pendingActivationItem = undefined;
           this._pendingActivationTimeout = undefined;
-          this._bindDelayedActivationHandler = this._delayedActivationHandler.bind(this);
-          this.addEventListener('blur', this._onBlurCapture.bind(this), true);
-        },
+        }
+      },
 
-        detached: function() {
+      _onArrowKeyup: function(event) {
+        if (this.autoselect) {
+          this._scheduleActivation(this.focusedItem, this.autoselectDelay);
+        }
+      },
+
+      _onBlurCapture: function(event) {
+        // Cancel a scheduled item activation (if any) when that item is
+        // blurred.
+        if (event.target === this._pendingActivationItem) {
           this._cancelPendingActivation();
-        },
+        }
+      },
 
-        _noinkChanged: function(noink) {
-          var childTabs = Polymer.dom(this).querySelectorAll('paper-tab');
-          childTabs.forEach(noink ? this._setNoinkAttribute : this._removeNoinkAttribute);
-        },
+      get _tabContainerScrollSize () {
+        return Math.max(
+          0,
+          this.$.tabsContainer.scrollWidth -
+            this.$.tabsContainer.offsetWidth
+        );
+      },
 
-        _setNoinkAttribute: function(element) {
-          element.setAttribute('noink', '');
-        },
+      __getRTL: function() {
+        if (this.__cachedRTL === undefined) {
+          this.__cachedRTL = this._isRTL;
+        }
+        return this.__cachedRTL;
+      },
 
-        _removeNoinkAttribute: function(element) {
-          element.removeAttribute('noink');
-        },
+      _scroll: function(e, detail) {
+        if (!this.scrollable) {
+          return;
+        }
 
-        _computeScrollButtonClass: function(hideThisButton, scrollable, hideScrollButtons) {
-          if (!scrollable || hideScrollButtons) {
-            return 'hidden';
-          }
+        var ddx = (detail && -detail.ddx) || 0;
+        this._affectScroll(ddx);
+      },
 
-          if (hideThisButton) {
-            return 'not-visible';
-          }
+      _onWheel: function(e) {
+        if (e.deltaX === 0) return;
 
-          return '';
-        },
+        var scrollFactor = 0;
+        switch (e.deltaMode) {
+          case WheelEvent.DOM_DELTA_PIXEL:
+            scrollFactor = 1;
+          break;
+          case WheelEvent.DOM_DELTA_LINE:
+            scrollFactor = parseFloat(getComputedStyle(this).fontSize);
+          break;
+          case WheelEvent.DOM_DELTA_PAGE:
+            scrollFactor = this.$.tabsContainer.getBoundingClientRect().width;
+          break;
+        }
 
-        _computeTabsContentClass: function(scrollable, fitContainer) {
-          return scrollable ? 'scrollable' + (fitContainer ? ' fit-container' : '') : ' fit-container';
-        },
-
-        _computeSelectionBarClass: function(noBar, alignBottom) {
-          if (noBar) {
-            return 'hidden';
-          } else if (alignBottom) {
-            return 'align-bottom';
-          }
-
-          return '';
-        },
-
-        // TODO(cdata): Add `track` response back in when gesture lands.
-
-        _onTabSizingChanged: function() {
-          this.debounce('_onTabSizingChanged', function() {
-            this._tabChanged(this.selectedItem);
-          }, 10);
-        },
-
-        _onIronSelect: function(event) {
-          this._tabChanged(event.detail.item, this._previousTab);
-          this._previousTab = event.detail.item;
-          this.cancelDebouncer('tab-changed');
-        },
-
-        _onIronDeselect: function(event) {
-          this.debounce('tab-changed', function() {
-            this._tabChanged(null, this._previousTab);
-            this._previousTab = null;
-          // See polymer/polymer#1305
-          }, 1);
-        },
-
-        _activateHandler: function() {
-          // Cancel item activations scheduled by keyboard events when any other
-          // action causes an item to be activated (e.g. clicks).
-          this._cancelPendingActivation();
-
-          Polymer.IronMenuBehaviorImpl._activateHandler.apply(this, arguments);
-        },
-
-        /**
-         * Activates an item after a delay (in milliseconds).
-         */
-        _scheduleActivation: function(item, delay) {
-          this._pendingActivationItem = item;
-          this._pendingActivationTimeout = this.async(
-              this._bindDelayedActivationHandler, delay);
-        },
-
-        /**
-         * Activates the last item given to `_scheduleActivation`.
-         */
-        _delayedActivationHandler: function() {
-          var item = this._pendingActivationItem;
-          this._pendingActivationItem = undefined;
-          this._pendingActivationTimeout = undefined;
-          item.fire(this.activateEvent, null, {
-            bubbles: true,
-            cancelable: true
-          });
-        },
-
-        /**
-         * Cancels a previously scheduled item activation made with
-         * `_scheduleActivation`.
-         */
-        _cancelPendingActivation: function() {
-          if (this._pendingActivationTimeout !== undefined) {
-            this.cancelAsync(this._pendingActivationTimeout);
-            this._pendingActivationItem = undefined;
-            this._pendingActivationTimeout = undefined;
-          }
-        },
-
-        _onArrowKeyup: function(event) {
-          if (this.autoselect) {
-            this._scheduleActivation(this.focusedItem, this.autoselectDelay);
-          }
-        },
-
-        _onBlurCapture: function(event) {
-          // Cancel a scheduled item activation (if any) when that item is
-          // blurred.
-          if (event.target === this._pendingActivationItem) {
-            this._cancelPendingActivation();
-          }
-        },
-
-        get _tabContainerScrollSize () {
-          return Math.max(
-            0,
-            this.$.tabsContainer.scrollWidth -
-              this.$.tabsContainer.offsetWidth
-          );
-        },
-
-        _getRTL: function() {
-          return this._cachedRTL !== undefined ? this._cachedRTL : this._isRTL;
-        },
-
-        _scroll: function(e, detail) {
-          if (!this.scrollable) {
-            return;
-          }
-
-          var ddx = (detail && -detail.ddx) || 0;
-          this._affectScroll(ddx);
-        },
-
-        _onWheel: function(e) {
-          if (e.deltaX === 0) return;
-
-          var scrollFactor = 0;
-          switch (e.deltaMode) {
-            case WheelEvent.DOM_DELTA_PIXEL:
-              scrollFactor = 1;
-            break;
-            case WheelEvent.DOM_DELTA_LINE:
-              scrollFactor = parseFloat(getComputedStyle(this).fontSize);
-            break;
-            case WheelEvent.DOM_DELTA_PAGE:
-              scrollFactor = this.$.tabsContainer.getBoundingClientRect().width;
-            break;
-          }
-
-          if (scrollFactor !== 0) {
-            e.preventDefault();
-            this._affectScroll(e.deltaX * scrollFactor);
-            this._updateScrollButtonsHiddenState();
-          }
-        },
-
-        _down: function(e) {
-          // go one beat async to defeat IronMenuBehavior
-          // autorefocus-on-no-selection timeout
-          this.async(function() {
-            if (this._defaultFocusAsync) {
-              this.cancelAsync(this._defaultFocusAsync);
-              this._defaultFocusAsync = null;
-            }
-          }, 1);
-        },
-
-        /**
-         * Adjusts `scrollLeft` by a relative amount, with positive values
-         * scrolling into view content hidden to the right (LTR-like),
-         * regardless of the element's current directionality.
-         */
-        _affectScroll: function(dx) {
-          this.$.tabsContainer.scrollLeft += (this._getRTL() && this.__rtlPositiveLeft ? -1 : 1) * dx;
+        if (scrollFactor !== 0) {
+          e.preventDefault();
+          this._affectScroll(e.deltaX * scrollFactor);
           this._updateScrollButtonsHiddenState();
-        },
+        }
+      },
 
-        /**
-         * Scrolls to a normalized (LTR-like) `scrollLeft` position, regardless
-         * of the element's current directionality.
-         */
-        _scrollToNormalizedLeft: function(normalizedLeft) {
-          this.$.tabsContainer.scrollLeft = this._normalizedLeftToScrollLeft(normalizedLeft);
-          this._updateScrollButtonsHiddenState();
-        },
+      _down: function(e) {
+        // go one beat async to defeat IronMenuBehavior
+        // autorefocus-on-no-selection timeout
+        this.async(function() {
+          if (this._defaultFocusAsync) {
+            this.cancelAsync(this._defaultFocusAsync);
+            this._defaultFocusAsync = null;
+          }
+        }, 1);
+      },
 
-        _updateScrollButtonsHiddenState: function() {
-          var normalizedLeft =
-            this._scrollLeftToNormalizedLeft(this.$.tabsContainer.scrollLeft);
+      /**
+       * Adjusts `scrollLeft` by a relative amount, with positive values
+       * scrolling into view content hidden to the right (LTR-like),
+       * regardless of the element's current directionality.
+       */
+      _affectScroll: function(dx) {
+        this.$.tabsContainer.scrollLeft += (this.__getRTL() && this.__getRTLPositiveLeft() ? -1 : 1) * dx;
+        this.__updateScrollButtonsHiddenState();
+      },
 
-          this._leftHidden = normalizedLeft <= 0;
-          this._rightHidden = normalizedLeft >= this._tabContainerScrollSize;
-        },
+      /**
+       * Scrolls to a normalized (LTR-like) `scrollLeft` position, regardless
+       * of the element's current directionality.
+       */
+      __scrollToNormalizedLeft: function(normalizedLeft) {
+        this.$.tabsContainer.scrollLeft = this.__normalizedLeftToScrollLeft(normalizedLeft);
+        this.__updateScrollButtonsHiddenState();
+      },
 
-        _onLeftScrollButtonDown: function() {
-          this._scrollToLeft();
-          this._holdJob = setInterval(this._scrollToLeft.bind(this), this._holdDelay);
-        },
+      __updateScrollButtonsHiddenState: function() {
+        var normalizedLeft =
+          this.__scrollLeftToNormalizedLeft(this.$.tabsContainer.scrollLeft);
 
-        _onRightScrollButtonDown: function() {
-          this._scrollToRight();
-          this._holdJob = setInterval(this._scrollToRight.bind(this), this._holdDelay);
-        },
+        this._leftHidden = normalizedLeft <= 0;
+        this._rightHidden = normalizedLeft >= this._tabContainerScrollSize;
+      },
 
-        _onScrollButtonUp: function() {
-          clearInterval(this._holdJob);
-          this._holdJob = null;
-        },
+      _onLeftScrollButtonDown: function() {
+        this._scrollToLeft();
+        this._holdJob = setInterval(this._scrollToLeft.bind(this), this._holdDelay);
+      },
 
-        _scrollToLeft: function() {
-          this._affectScroll(-this._step);
-        },
+      _onRightScrollButtonDown: function() {
+        this._scrollToRight();
+        this._holdJob = setInterval(this._scrollToRight.bind(this), this._holdDelay);
+      },
 
-        _scrollToRight: function() {
-          this._affectScroll(this._step);
-        },
+      _onScrollButtonUp: function() {
+        clearInterval(this._holdJob);
+        this._holdJob = null;
+      },
 
-        _tabChanged: function(tab, old) {
-          if (!tab) {
-            // Remove the bar without animation.
-            this.$.selectionBar.classList.remove('expand');
-            this.$.selectionBar.classList.remove('contract');
-            this._positionBar(0, 0);
-            return;
+      _scrollToLeft: function() {
+        this._affectScroll(-this._step);
+      },
+
+      _scrollToRight: function() {
+        this._affectScroll(this._step);
+      },
+
+      _tabChanged: function(tab, old) {
+        if (!tab) {
+          // Remove the bar without animation.
+          this.$.selectionBar.classList.remove('expand');
+          this.$.selectionBar.classList.remove('contract');
+          this._positionBar(0, 0);
+          return;
+        }
+
+        var r = this.$.tabsContent.getBoundingClientRect();
+        var w = r.width;
+        var tabRect = tab.getBoundingClientRect();
+        var tabOffsetLeft = tabRect.left - r.left;
+
+        this._pos = {
+          width: this._calcPercent(tabRect.width, w),
+          left: this._calcPercent(tabOffsetLeft, w)
+        };
+
+        if (this.noSlide || old == null) {
+          // Position the bar without animation.
+          this.$.selectionBar.classList.remove('expand');
+          this.$.selectionBar.classList.remove('contract');
+          this._positionBar(this._pos.width, this._pos.left);
+        } else {
+          var oldRect = old.getBoundingClientRect();
+          var oldIndex = this.items.indexOf(old);
+          var index = this.items.indexOf(tab);
+          var m = 5;
+
+          // bar animation: expand
+          this.$.selectionBar.classList.add('expand');
+
+          var moveRight = oldIndex < index;
+          var isRTL = this.__getRTL();
+          if (isRTL) {
+            moveRight = !moveRight;
           }
 
-          var r = this.$.tabsContent.getBoundingClientRect();
-          var w = r.width;
-          var tabRect = tab.getBoundingClientRect();
-          var tabOffsetLeft = tabRect.left - r.left;
-
-          this._pos = {
-            width: this._calcPercent(tabRect.width, w),
-            left: this._calcPercent(tabOffsetLeft, w)
-          };
-
-          if (this.noSlide || old == null) {
-            // Position the bar without animation.
-            this.$.selectionBar.classList.remove('expand');
-            this.$.selectionBar.classList.remove('contract');
-            this._positionBar(this._pos.width, this._pos.left);
+          if (moveRight) {
+            this._positionBar(this._calcPercent(tabRect.left + tabRect.width - oldRect.left, w) - m,
+                this._left);
           } else {
-            var oldRect = old.getBoundingClientRect();
-            var oldIndex = this.items.indexOf(old);
-            var index = this.items.indexOf(tab);
-            var m = 5;
-
-            // bar animation: expand
-            this.$.selectionBar.classList.add('expand');
-
-            var moveRight = oldIndex < index;
-            var isRTL = this._getRTL();
-            if (isRTL) {
-              moveRight = !moveRight;
-            }
-
-            if (moveRight) {
-              this._positionBar(this._calcPercent(tabRect.left + tabRect.width - oldRect.left, w) - m,
-                  this._left);
-            } else {
-              this._positionBar(this._calcPercent(oldRect.left + oldRect.width - tabRect.left, w) - m,
-                  this._calcPercent(tabOffsetLeft, w) + m);
-            }
+            this._positionBar(this._calcPercent(oldRect.left + oldRect.width - tabRect.left, w) - m,
+                this._calcPercent(tabOffsetLeft, w) + m);
           }
+        }
 
-          if (this.scrollable) {
-            this._scrollToSelectedIfNeeded(tabRect.width, tabOffsetLeft);
-          }
+        if (this.scrollable) {
+          this._scrollToSelectedIfNeeded(tabRect.width, tabOffsetLeft);
+        }
 
-          this._updateScrollButtonsHiddenState();
-        },
+        this.__updateScrollButtonsHiddenState();
+      },
 
-        _scrollToSelectedIfNeeded: function(tabWidth, tabOffsetLeft) {
-          var containerRect = this.$.tabsContainer.getBoundingClientRect();
-          var tabRect = this.selectedItem.getBoundingClientRect();
-          var normalizedLeft =
-            this._scrollLeftToNormalizedLeft(this.$.tabsContainer.scrollLeft);
+      _scrollToSelectedIfNeeded: function(tabWidth, tabOffsetLeft) {
+        var containerRect = this.$.tabsContainer.getBoundingClientRect();
+        var tabRect = this.selectedItem.getBoundingClientRect();
+        var normalizedLeft =
+          this.__scrollLeftToNormalizedLeft(this.$.tabsContainer.scrollLeft);
 
-          if (tabOffsetLeft < normalizedLeft) {
-            this._scrollToNormalizedLeft(tabOffsetLeft);
-          } else if (normalizedLeft + containerRect.width < tabOffsetLeft + tabWidth) {
-            this._scrollToNormalizedLeft(tabOffsetLeft + tabWidth - containerRect.width);
-          }
-        },
+        if (tabOffsetLeft < normalizedLeft) {
+          this.__scrollToNormalizedLeft(tabOffsetLeft);
+        } else if (normalizedLeft + containerRect.width < tabOffsetLeft + tabWidth) {
+          this.__scrollToNormalizedLeft(tabOffsetLeft + tabWidth - containerRect.width);
+        }
+      },
 
-        _calcPercent: function(w, w0) {
-          return 100 * w / w0;
-        },
+      _calcPercent: function(w, w0) {
+        return 100 * w / w0;
+      },
 
-        _positionBar: function(width, left) {
-          width = width || 0;
-          left = left || 0;
+      _positionBar: function(width, left) {
+        width = width || 0;
+        left = left || 0;
 
-          this._width = width;
-          this._left = left;
-          this.transform(
-              'translateX(' + left + '%) scaleX(' + (width / 100) + ')',
-              this.$.selectionBar);
-        },
+        this._width = width;
+        this._left = left;
+        this.transform(
+            'translateX(' + left + '%) scaleX(' + (width / 100) + ')',
+            this.$.selectionBar);
+      },
 
-        _onBarTransitionEnd: function(e) {
-          var cl = this.$.selectionBar.classList;
-          // bar animation: expand -> contract
-          if (cl.contains('expand')) {
-            cl.remove('expand');
-            cl.add('contract');
-            this._positionBar(this._pos.width, this._pos.left);
-          // bar animation done
-          } else if (cl.contains('contract')) {
-            cl.remove('contract');
-          }
-        },
+      _onBarTransitionEnd: function(e) {
+        var cl = this.$.selectionBar.classList;
+        // bar animation: expand -> contract
+        if (cl.contains('expand')) {
+          cl.remove('expand');
+          cl.add('contract');
+          this._positionBar(this._pos.width, this._pos.left);
+        // bar animation done
+        } else if (cl.contains('contract')) {
+          cl.remove('contract');
+        }
+      },
 
-        /**
-         * Normalizes a value returned by `scrollLeft`, which can be writing
-         * direction dependent, to its LTR equivalent.
-         */
-        _scrollLeftToNormalizedLeft: function(scrollLeft) {
-          if (this._getRTL()) {
-            var normalizedLeft = scrollLeft;
-            normalizedLeft *= this.__rtlPositiveLeft ? -1 : 1;
-            normalizedLeft += this.__rtlZeroRight ? this._tabContainerScrollSize : 0;
-            return normalizedLeft;
-          } else {
-            return scrollLeft;
-          }
-        },
+      /**
+       * Normalizes a value returned by `scrollLeft`, which can be writing
+       * direction dependent, to its LTR equivalent.
+       */
+      __scrollLeftToNormalizedLeft: function(scrollLeft) {
+        if (this.__getRTL()) {
+          var normalizedLeft = scrollLeft;
+          normalizedLeft *= this.__getRTLPositiveLeft() ? -1 : 1;
+          normalizedLeft += this.__getRTLZeroRight() ? this._tabContainerScrollSize : 0;
+          return normalizedLeft;
+        } else {
+          return scrollLeft;
+        }
+      },
 
-        /**
-         * Converts normalized (LTR-like) `scrollLeft` values to the browser
-         * specific value based on the element's current directionality.
-         */
-        _normalizedLeftToScrollLeft: function(normalizedLeft) {
-          if (this._getRTL()) {
-            var scrollLeft = normalizedLeft;
-            scrollLeft -= this.__rtlZeroRight ? this._tabContainerScrollSize : 0;
-            scrollLeft *= this.__rtlPositiveLeft ? -1 : 1;
-            return scrollLeft;
-          } else {
-            return normalizedLeft;
-          }
-        },
+      /**
+       * Converts normalized (LTR-like) `scrollLeft` values to the browser
+       * specific value based on the element's current directionality.
+       */
+      __normalizedLeftToScrollLeft: function(normalizedLeft) {
+        if (this.__getRTL()) {
+          var scrollLeft = normalizedLeft;
+          scrollLeft -= this.__getRTLZeroRight() ? this._tabContainerScrollSize : 0;
+          scrollLeft *= this.__getRTLPositiveLeft() ? -1 : 1;
+          return scrollLeft;
+        } else {
+          return normalizedLeft;
+        }
+      },
 
-        get __rtlZeroRight() {
-          if (RTL_ZERO_RIGHT === undefined) {
-            this.__checkRTLBehavior();
-          }
+      __getRTLZeroRight: function() {
+        if (this.__rtlZeroRight === undefined) {
+          this.__checkRTLBehavior();
+        }
 
-          return RTL_ZERO_RIGHT;
-        },
+        return this.__rtlZeroRight;
+      },
 
-        get __rtlPositiveLeft() {
-          if (RTL_POSITIVE_LEFT === undefined) {
-            this.__checkRTLBehavior();
-          }
+      __getRTLPositiveLeft: function() {
+        if (this.__rtlPositiveLeft === undefined) {
+          this.__checkRTLBehavior();
+        }
 
-          return RTL_POSITIVE_LEFT;
-        },
+        return this.__rtlPositiveLeft;
+      },
 
-        __checkRTLBehavior: function() {
-          var outer = document.createElement('div');
-          outer.setAttribute('dir', 'rtl');
-          outer.style.position = 'absolute';
-          outer.style.width = '50px';
-          outer.style.height = '50px';
-          outer.style.overflow = 'hidden';
+      __checkRTLBehavior: function() {
+        var prototype = Object.getPrototypeOf(this);
 
-          var inner = document.createElement('div');
-          inner.style.width = '100px';
-          inner.style.height = '100px';
-          outer.appendChild(inner);
+        var outer = document.createElement('div');
+        outer.setAttribute('dir', 'rtl');
+        outer.style.position = 'absolute';
+        outer.style.width = '50px';
+        outer.style.height = '50px';
+        outer.style.overflow = 'hidden';
 
-          document.body.appendChild(outer);
+        var inner = document.createElement('div');
+        inner.style.width = '100px';
+        inner.style.height = '100px';
+        outer.appendChild(inner);
 
-          // Is this container's non-zero-edge alignment represented by a
-          // positive or negative value? (Are we able to scroll to a negative
-          // value when the only overflowing content is positioned positively?)
-          outer.scrollLeft = -10000;
-          var fullScrollNegative = outer.scrollLeft < 0;
+        document.body.appendChild(outer);
 
-          // Are the right edges of the container and its overflowing content
-          // aligned when `scrollLeft` is zero? (The overflowing content is
-          // larger than the container, so only one set of edges can be
-          // aligned.)
-          outer.scrollLeft = 0;
-          var innerStartRect = inner.getBoundingClientRect();
-          var outerStartRect = outer.getBoundingClientRect();
-          RTL_ZERO_RIGHT = innerStartRect.right === outerStartRect.right;
+        // Is this container's non-zero-edge alignment represented by a
+        // positive or negative value? (Are we able to scroll to a negative
+        // value when the only overflowing content is positioned positively?)
+        outer.scrollLeft = -10000;
+        var fullScrollNegative = outer.scrollLeft < 0;
 
-          // Scroll to the end of the scrollable area in the available non-zero
-          // direction.
-          outer.scrollLeft += (fullScrollNegative ? -1 : 1) * 10000;
-          var innerEndRect = inner.getBoundingClientRect();
+        // Are the right edges of the container and its overflowing content
+        // aligned when `scrollLeft` is zero? (The overflowing content is
+        // larger than the container, so only one set of edges can be
+        // aligned.)
+        outer.scrollLeft = 0;
+        var innerStartRect = inner.getBoundingClientRect();
+        var outerStartRect = outer.getBoundingClientRect();
+        prototype.__rtlZeroRight = innerStartRect.right === outerStartRect.right;
 
-          // If the change made to `scrollLeft` and the amount by which its
-          // overflowing content's bounding box moved have matching signs, then
-          // left is the positive direction.
-          var contentMovementNegative = innerEndRect.left < innerStartRect.left;
-          RTL_POSITIVE_LEFT = fullScrollNegative === contentMovementNegative;
+        // Scroll to the end of the scrollable area in the available non-zero
+        // direction.
+        outer.scrollLeft += (fullScrollNegative ? -1 : 1) * 10000;
+        var innerEndRect = inner.getBoundingClientRect();
 
-          document.body.removeChild(outer);
-        },
-      });
-    })();
+        // If the change made to `scrollLeft` and the amount by which its
+        // overflowing content's bounding box moved have matching signs, then
+        // left is the positive direction.
+        var contentMovementNegative = innerEndRect.left < innerStartRect.left;
+        prototype.__rtlPositiveLeft = fullScrollNegative === contentMovementNegative;
+
+        document.body.removeChild(outer);
+      },
+    });
   </script>
 </dom-module>

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -127,6 +127,7 @@ Custom property | Description | Default
         height: 100%;
         white-space: nowrap;
         overflow: hidden;
+        -webkit-overflow-scrolling: touch;
         @apply(--layout-flex-auto);
         @apply(--paper-tabs-container);
       }
@@ -215,7 +216,7 @@ Custom property | Description | Default
 
     <paper-icon-button icon="paper-tabs:chevron-left" class$="[[_computeScrollButtonClass(_leftHidden, scrollable, hideScrollButtons)]]" on-up="_onScrollButtonUp" on-down="_onLeftScrollButtonDown" tabindex="-1"></paper-icon-button>
 
-    <div id="tabsContainer" on-track="_scroll" on-down="_down">
+    <div id="tabsContainer" on-track="_onTrack" on-wheel="_onWheel" on-down="_down">
       <div id="tabsContent" class$="[[_computeTabsContentClass(scrollable, fitContainer)]]">
         <div id="selectionBar" class$="[[_computeSelectionBarClass(noBar, alignBottom)]]"
             on-transitionend="_onBarTransitionEnd"></div>
@@ -228,434 +229,586 @@ Custom property | Description | Default
   </template>
 
   <script>
-    Polymer({
-      is: 'paper-tabs',
+    (function() {
+      // True if, when an element has RTL directionality, `scrollLeft` is zero
+      // when the right edge of the scrollable area is aligned with the right
+      // edge of its overflowing content.
+      // (As opposed to LTR, where `scrollLeft` is zero when when the left edge
+      // of the scrollable area is aligned with the left edge of its overflowing
+      // content.)
+      var RTL_ZERO_RIGHT = false;
 
-      behaviors: [
-        Polymer.IronResizableBehavior,
-        Polymer.IronMenubarBehavior
-      ],
+      // True if, when an element has RTL directionality, positive changes to
+      // `scrollLeft` cause the scrollable area to show content that is further
+      // to the left.
+      // (As opposed to LTR, where positive changes to `scrollLeft` cause the
+      // scrollable area to show overflowing content that is further to the
+      // right.)
+      var RTL_POSITIVE_LEFT = false;
 
-      properties: {
-        /**
-         * If true, ink ripple effect is disabled. When this property is changed,
-         * all descendant `<paper-tab>` elements have their `noink` property
-         * changed to the new value as well.
-         */
-        noink: {
-          type: Boolean,
-          value: false,
-          observer: '_noinkChanged'
-        },
+      var SCROLLBAR_HEIGHT = 16;
 
-        /**
-         * If true, the bottom bar to indicate the selected tab will not be shown.
-         */
-        noBar: {
-          type: Boolean,
-          value: false
-        },
+      (function() {
+        function testRTLScrollLeftBehavior() {
+          var outer = document.createElement('div');
+          outer.setAttribute('dir', 'rtl');
+          outer.style.position = 'absolute';
+          outer.style.width = '50px';
+          outer.style.height = '50px';
+          outer.style.overflow = 'hidden';
 
-        /**
-         * If true, the slide effect for the bottom bar is disabled.
-         */
-        noSlide: {
-          type: Boolean,
-          value: false
-        },
+          var inner = document.createElement('div');
+          inner.style.width = '100px';
+          inner.style.height = '100px';
+          outer.appendChild(inner);
 
-        /**
-         * If true, tabs are scrollable and the tab width is based on the label width.
-         */
-        scrollable: {
-          type: Boolean,
-          value: false
-        },
+          document.body.appendChild(outer);
 
-        /**
-         * If true, tabs expand to fit their container. This currently only applies when
-         * scrollable is true.
-         */
-        fitContainer: {
-          type: Boolean,
-          value: false
-        },
+          // Is this container's non-zero-edge alignment represented by a
+          // positive or negative value? (Are we able to scroll to a negative
+          // value when the only overflowing content is positioned positively?)
+          outer.scrollLeft = -10000;
+          var fullScrollNegative = outer.scrollLeft < 0;
 
-        /**
-         * If true, dragging on the tabs to scroll is disabled.
-         */
-        disableDrag: {
-          type: Boolean,
-          value: false
-        },
+          // Are the right edges of the container and its overflowing content
+          // aligned when `scrollLeft` is zero? (The overflowing content is
+          // larger than the container, so only one set of edges can be
+          // aligned.)
+          outer.scrollLeft = 0;
+          var innerStartRect = inner.getBoundingClientRect();
+          var outerStartRect = outer.getBoundingClientRect();
+          RTL_ZERO_RIGHT = innerStartRect.right === outerStartRect.right;
 
-        /**
-         * If true, scroll buttons (left/right arrow) will be hidden for scrollable tabs.
-         */
-        hideScrollButtons: {
-          type: Boolean,
-          value: false
-        },
+          // Scroll to the end of the scrollable area in the available non-zero
+          // direction.
+          outer.scrollLeft += (fullScrollNegative ? -1 : 1) * 10000;
+          var innerEndRect = inner.getBoundingClientRect();
 
-        /**
-         * If true, the tabs are aligned to bottom (the selection bar appears at the top).
-         */
-        alignBottom: {
-          type: Boolean,
-          value: false
-        },
+          // If the change made to `scrollLeft` and the amount by which its
+          // overflowing content's bounding box moved have matching signs, then
+          // left is the positive direction.
+          var contentMovementNegative = innerEndRect.left < innerStartRect.left;
+          RTL_POSITIVE_LEFT = fullScrollNegative === contentMovementNegative;
 
-        selectable: {
-          type: String,
-          value: 'paper-tab'
-        },
+          outer.style.overflow = 'scroll';
+          SCROLLBAR_HEIGHT = outer.offsetHeight - outer.clientHeight;
 
-        /**
-         * If true, tabs are automatically selected when focused using the
-         * keyboard.
-         */
-        autoselect: {
-          type: Boolean,
-          value: false
-        },
-
-        /**
-         * The delay (in milliseconds) between when the user stops interacting
-         * with the tabs through the keyboard and when the focused item is
-         * automatically selected (if `autoselect` is true).
-         */
-        autoselectDelay: {
-          type: Number,
-          value: 0
-        },
-
-        _step: {
-          type: Number,
-          value: 10
-        },
-
-        _holdDelay: {
-          type: Number,
-          value: 1
-        },
-
-        _leftHidden: {
-          type: Boolean,
-          value: false
-        },
-
-        _rightHidden: {
-          type: Boolean,
-          value: false
-        },
-
-        _previousTab: {
-          type: Object
-        }
-      },
-
-      hostAttributes: {
-        role: 'tablist'
-      },
-
-      listeners: {
-        'iron-resize': '_onTabSizingChanged',
-        'iron-items-changed': '_onTabSizingChanged',
-        'iron-select': '_onIronSelect',
-        'iron-deselect': '_onIronDeselect'
-      },
-
-      keyBindings: {
-        'left:keyup right:keyup': '_onArrowKeyup'
-      },
-
-      created: function() {
-        this._holdJob = null;
-        this._pendingActivationItem = undefined;
-        this._pendingActivationTimeout = undefined;
-        this._bindDelayedActivationHandler = this._delayedActivationHandler.bind(this);
-        this.addEventListener('blur', this._onBlurCapture.bind(this), true);
-      },
-
-      ready: function() {
-        this.setScrollDirection('y', this.$.tabsContainer);
-      },
-
-      detached: function() {
-        this._cancelPendingActivation();
-      },
-
-      _noinkChanged: function(noink) {
-        var childTabs = Polymer.dom(this).querySelectorAll('paper-tab');
-        childTabs.forEach(noink ? this._setNoinkAttribute : this._removeNoinkAttribute);
-      },
-
-      _setNoinkAttribute: function(element) {
-        element.setAttribute('noink', '');
-      },
-
-      _removeNoinkAttribute: function(element) {
-        element.removeAttribute('noink');
-      },
-
-      _computeScrollButtonClass: function(hideThisButton, scrollable, hideScrollButtons) {
-        if (!scrollable || hideScrollButtons) {
-          return 'hidden';
-        }
-
-        if (hideThisButton) {
-          return 'not-visible';
-        }
-
-        return '';
-      },
-
-      _computeTabsContentClass: function(scrollable, fitContainer) {
-        return scrollable ? 'scrollable' + (fitContainer ? ' fit-container' : '') : ' fit-container';
-      },
-
-      _computeSelectionBarClass: function(noBar, alignBottom) {
-        if (noBar) {
-          return 'hidden';
-        } else if (alignBottom) {
-          return 'align-bottom';
-        }
-
-        return '';
-      },
-
-      // TODO(cdata): Add `track` response back in when gesture lands.
-
-      _onTabSizingChanged: function() {
-        this.debounce('_onTabSizingChanged', function() {
-          this._scroll();
-          this._tabChanged(this.selectedItem);
-        }, 10);
-      },
-
-      _onIronSelect: function(event) {
-        this._tabChanged(event.detail.item, this._previousTab);
-        this._previousTab = event.detail.item;
-        this.cancelDebouncer('tab-changed');
-      },
-
-      _onIronDeselect: function(event) {
-        this.debounce('tab-changed', function() {
-          this._tabChanged(null, this._previousTab);
-          this._previousTab = null;
-        // See polymer/polymer#1305
-        }, 1);
-      },
-
-      _activateHandler: function() {
-        // Cancel item activations scheduled by keyboard events when any other
-        // action causes an item to be activated (e.g. clicks).
-        this._cancelPendingActivation();
-
-        Polymer.IronMenuBehaviorImpl._activateHandler.apply(this, arguments);
-      },
-
-      /**
-       * Activates an item after a delay (in milliseconds).
-       */
-      _scheduleActivation: function(item, delay) {
-        this._pendingActivationItem = item;
-        this._pendingActivationTimeout = this.async(
-            this._bindDelayedActivationHandler, delay);
-      },
-
-      /**
-       * Activates the last item given to `_scheduleActivation`.
-       */
-      _delayedActivationHandler: function() {
-        var item = this._pendingActivationItem;
-        this._pendingActivationItem = undefined;
-        this._pendingActivationTimeout = undefined;
-        item.fire(this.activateEvent, null, {
-          bubbles: true,
-          cancelable: true
-        });
-      },
-
-      /**
-       * Cancels a previously scheduled item activation made with
-       * `_scheduleActivation`.
-       */
-      _cancelPendingActivation: function() {
-        if (this._pendingActivationTimeout !== undefined) {
-          this.cancelAsync(this._pendingActivationTimeout);
-          this._pendingActivationItem = undefined;
-          this._pendingActivationTimeout = undefined;
-        }
-      },
-
-      _onArrowKeyup: function(event) {
-        if (this.autoselect) {
-          this._scheduleActivation(this.focusedItem, this.autoselectDelay);
-        }
-      },
-
-      _onBlurCapture: function(event) {
-        // Cancel a scheduled item activation (if any) when that item is
-        // blurred.
-        if (event.target === this._pendingActivationItem) {
-          this._cancelPendingActivation();
-        }
-      },
-
-      get _tabContainerScrollSize () {
-        return Math.max(
-          0,
-          this.$.tabsContainer.scrollWidth -
-            this.$.tabsContainer.offsetWidth
-        );
-      },
-
-      _scroll: function(e, detail) {
-        if (!this.scrollable) {
-          return;
-        }
-
-        var ddx = (detail && -detail.ddx) || 0;
-        this._affectScroll(ddx);
-      },
-
-      _down: function(e) {
-        // go one beat async to defeat IronMenuBehavior
-        // autorefocus-on-no-selection timeout
-        this.async(function() {
-          if (this._defaultFocusAsync) {
-            this.cancelAsync(this._defaultFocusAsync);
-            this._defaultFocusAsync = null;
-          }
-        }, 1);
-      },
-
-      _affectScroll: function(dx) {
-        this.$.tabsContainer.scrollLeft += dx;
-
-        var scrollLeft = this.$.tabsContainer.scrollLeft;
-
-        this._leftHidden = scrollLeft === 0;
-        this._rightHidden = scrollLeft === this._tabContainerScrollSize;
-      },
-
-      _onLeftScrollButtonDown: function() {
-        this._scrollToLeft();
-        this._holdJob = setInterval(this._scrollToLeft.bind(this), this._holdDelay);
-      },
-
-      _onRightScrollButtonDown: function() {
-        this._scrollToRight();
-        this._holdJob = setInterval(this._scrollToRight.bind(this), this._holdDelay);
-      },
-
-      _onScrollButtonUp: function() {
-        clearInterval(this._holdJob);
-        this._holdJob = null;
-      },
-
-      _scrollToLeft: function() {
-        this._affectScroll(-this._step);
-      },
-
-      _scrollToRight: function() {
-        this._affectScroll(this._step);
-      },
-
-      _tabChanged: function(tab, old) {
-        if (!tab) {
-          // Remove the bar without animation.
-          this.$.selectionBar.classList.remove('expand');
-          this.$.selectionBar.classList.remove('contract');
-          this._positionBar(0, 0);
-          return;
-        }
-
-        var r = this.$.tabsContent.getBoundingClientRect();
-        var w = r.width;
-        var tabRect = tab.getBoundingClientRect();
-        var tabOffsetLeft = tabRect.left - r.left;
-
-        this._pos = {
-          width: this._calcPercent(tabRect.width, w),
-          left: this._calcPercent(tabOffsetLeft, w)
+          document.body.removeChild(outer);
         };
 
-        if (this.noSlide || old == null) {
-          // Position the bar without animation.
-          this.$.selectionBar.classList.remove('expand');
-          this.$.selectionBar.classList.remove('contract');
-          this._positionBar(this._pos.width, this._pos.left);
-          return;
-        }
-
-        var oldRect = old.getBoundingClientRect();
-        var oldIndex = this.items.indexOf(old);
-        var index = this.items.indexOf(tab);
-        var m = 5;
-
-        // bar animation: expand
-        this.$.selectionBar.classList.add('expand');
-
-        var moveRight = oldIndex < index;
-        var isRTL = this._isRTL;
-        if (isRTL) {
-          moveRight = !moveRight;
-        }
-
-        if (moveRight) {
-          this._positionBar(this._calcPercent(tabRect.left + tabRect.width - oldRect.left, w) - m,
-              this._left);
+        // Wait for the load event if necessary, otherwise
+        // `getBoundingClientRect` will only return rectangles with all values
+        // set to zero.
+        if (document.readyState === 'complete') {
+          testRTLScrollLeftBehavior();
         } else {
-          this._positionBar(this._calcPercent(oldRect.left + oldRect.width - tabRect.left, w) - m,
-              this._calcPercent(tabOffsetLeft, w) + m);
+          window.addEventListener('load', function onLoad() {
+            window.removeEventListener('load', onLoad);
+            testRTLScrollLeftBehavior();
+          });
         }
+      })();
 
-        if (this.scrollable) {
-          this._scrollToSelectedIfNeeded(tabRect.width, tabOffsetLeft);
-        }
-      },
+      Polymer({
+        is: 'paper-tabs',
 
-      _scrollToSelectedIfNeeded: function(tabWidth, tabOffsetLeft) {
-        var l = tabOffsetLeft - this.$.tabsContainer.scrollLeft;
-        if (l < 0) {
-          this.$.tabsContainer.scrollLeft += l;
-        } else {
-          l += (tabWidth - this.$.tabsContainer.offsetWidth);
-          if (l > 0) {
-            this.$.tabsContainer.scrollLeft += l;
+        behaviors: [
+          Polymer.IronResizableBehavior,
+          Polymer.IronMenubarBehavior
+        ],
+
+        properties: {
+          /**
+           * If true, ink ripple effect is disabled. When this property is changed,
+           * all descendant `<paper-tab>` elements have their `noink` property
+           * changed to the new value as well.
+           */
+          noink: {
+            type: Boolean,
+            value: false,
+            observer: '_noinkChanged'
+          },
+
+          /**
+           * If true, the bottom bar to indicate the selected tab will not be shown.
+           */
+          noBar: {
+            type: Boolean,
+            value: false
+          },
+
+          /**
+           * If true, the slide effect for the bottom bar is disabled.
+           */
+          noSlide: {
+            type: Boolean,
+            value: false
+          },
+
+          /**
+           * If true, tabs are scrollable and the tab width is based on the label width.
+           */
+          scrollable: {
+            type: Boolean,
+            value: false
+          },
+
+          /**
+           * If true, tabs expand to fit their container. This currently only applies when
+           * scrollable is true.
+           */
+          fitContainer: {
+            type: Boolean,
+            value: false
+          },
+
+          /**
+           * If true, dragging on the tabs to scroll is disabled.
+           */
+          disableDrag: {
+            type: Boolean,
+            value: false
+          },
+
+          /**
+           * If true, scroll buttons (left/right arrow) will be hidden for scrollable tabs.
+           */
+          hideScrollButtons: {
+            type: Boolean,
+            value: false
+          },
+
+          /**
+           * If true, the tabs are aligned to bottom (the selection bar appears at the top).
+           */
+          alignBottom: {
+            type: Boolean,
+            value: false
+          },
+
+          selectable: {
+            type: String,
+            value: 'paper-tab'
+          },
+
+          /**
+           * If true, tabs are automatically selected when focused using the
+           * keyboard.
+           */
+          autoselect: {
+            type: Boolean,
+            value: false
+          },
+
+          /**
+           * The delay (in milliseconds) between when the user stops interacting
+           * with the tabs through the keyboard and when the focused item is
+           * automatically selected (if `autoselect` is true).
+           */
+          autoselectDelay: {
+            type: Number,
+            value: 0
+          },
+
+          _step: {
+            type: Number,
+            value: 10
+          },
+
+          _holdDelay: {
+            type: Number,
+            value: 1
+          },
+
+          _leftHidden: {
+            type: Boolean,
+            value: false
+          },
+
+          _rightHidden: {
+            type: Boolean,
+            value: false
+          },
+
+          _previousTab: {
+            type: Object
+          }
+        },
+
+        hostAttributes: {
+          role: 'tablist'
+        },
+
+        listeners: {
+          'iron-resize': '_onTabSizingChanged',
+          'iron-items-changed': '_onTabSizingChanged',
+          'iron-select': '_onIronSelect',
+          'iron-deselect': '_onIronDeselect'
+        },
+
+        keyBindings: {
+          'left:keyup right:keyup': '_onArrowKeyup'
+        },
+
+        created: function() {
+          this._holdJob = null;
+          this._pendingActivationItem = undefined;
+          this._pendingActivationTimeout = undefined;
+          this._bindDelayedActivationHandler = this._delayedActivationHandler.bind(this);
+          this.addEventListener('blur', this._onBlurCapture.bind(this), true);
+        },
+
+        detached: function() {
+          this._cancelPendingActivation();
+        },
+
+        _noinkChanged: function(noink) {
+          var childTabs = Polymer.dom(this).querySelectorAll('paper-tab');
+          childTabs.forEach(noink ? this._setNoinkAttribute : this._removeNoinkAttribute);
+        },
+
+        _setNoinkAttribute: function(element) {
+          element.setAttribute('noink', '');
+        },
+
+        _removeNoinkAttribute: function(element) {
+          element.removeAttribute('noink');
+        },
+
+        _computeScrollButtonClass: function(hideThisButton, scrollable, hideScrollButtons) {
+          if (!scrollable || hideScrollButtons) {
+            return 'hidden';
+          }
+
+          if (hideThisButton) {
+            return 'not-visible';
+          }
+
+          return '';
+        },
+
+        _computeTabsContentClass: function(scrollable, fitContainer) {
+          return scrollable ? 'scrollable' + (fitContainer ? ' fit-container' : '') : ' fit-container';
+        },
+
+        _computeSelectionBarClass: function(noBar, alignBottom) {
+          if (noBar) {
+            return 'hidden';
+          } else if (alignBottom) {
+            return 'align-bottom';
+          }
+
+          return '';
+        },
+
+        // TODO(cdata): Add `track` response back in when gesture lands.
+
+        _onTabSizingChanged: function() {
+          this.debounce('_onTabSizingChanged', function() {
+            this._tabChanged(this.selectedItem);
+          }, 10);
+        },
+
+        _onIronSelect: function(event) {
+          this._tabChanged(event.detail.item, this._previousTab);
+          this._previousTab = event.detail.item;
+          this.cancelDebouncer('tab-changed');
+        },
+
+        _onIronDeselect: function(event) {
+          this.debounce('tab-changed', function() {
+            this._tabChanged(null, this._previousTab);
+            this._previousTab = null;
+          // See polymer/polymer#1305
+          }, 1);
+        },
+
+        _activateHandler: function() {
+          // Cancel item activations scheduled by keyboard events when any other
+          // action causes an item to be activated (e.g. clicks).
+          this._cancelPendingActivation();
+
+          Polymer.IronMenuBehaviorImpl._activateHandler.apply(this, arguments);
+        },
+
+        /**
+         * Activates an item after a delay (in milliseconds).
+         */
+        _scheduleActivation: function(item, delay) {
+          this._pendingActivationItem = item;
+          this._pendingActivationTimeout = this.async(
+              this._bindDelayedActivationHandler, delay);
+        },
+
+        /**
+         * Activates the last item given to `_scheduleActivation`.
+         */
+        _delayedActivationHandler: function() {
+          var item = this._pendingActivationItem;
+          this._pendingActivationItem = undefined;
+          this._pendingActivationTimeout = undefined;
+          item.fire(this.activateEvent, null, {
+            bubbles: true,
+            cancelable: true
+          });
+        },
+
+        /**
+         * Cancels a previously scheduled item activation made with
+         * `_scheduleActivation`.
+         */
+        _cancelPendingActivation: function() {
+          if (this._pendingActivationTimeout !== undefined) {
+            this.cancelAsync(this._pendingActivationTimeout);
+            this._pendingActivationItem = undefined;
+            this._pendingActivationTimeout = undefined;
+          }
+        },
+
+        _onArrowKeyup: function(event) {
+          if (this.autoselect) {
+            this._scheduleActivation(this.focusedItem, this.autoselectDelay);
+          }
+        },
+
+        _onBlurCapture: function(event) {
+          // Cancel a scheduled item activation (if any) when that item is
+          // blurred.
+          if (event.target === this._pendingActivationItem) {
+            this._cancelPendingActivation();
+          }
+        },
+
+        get _tabContainerScrollSize () {
+          return Math.max(
+            0,
+            this.$.tabsContainer.scrollWidth -
+              this.$.tabsContainer.offsetWidth
+          );
+        },
+
+        _getRTL: function() {
+          return this._cachedRTL !== undefined ? this._cachedRTL : this._isRTL;
+        },
+
+        _onTrack: function(e, detail) {
+          if (!this.scrollable) return;
+
+          if (detail && detail.ddx !== undefined) {
+            this._affectScroll(-detail.ddx);
+          }
+        },
+
+        _onWheel: function(e) {
+          if (e.deltaX === 0) return;
+
+          var scrollFactor = 0;
+          switch (e.deltaMode) {
+            case WheelEvent.DOM_DELTA_PIXEL:
+              scrollFactor = 1;
+            break;
+            case WheelEvent.DOM_DELTA_LINE:
+              scrollFactor = parseFloat(getComputedStyle(this).fontSize);
+            break;
+            case WheelEvent.DOM_DELTA_PAGE:
+              scrollFactor = this.$.tabsContainer.getBoundingClientRect().width;
+            break;
+          }
+
+          if (scrollFactor !== 0) {
+            e.preventDefault();
+            this._affectScroll(e.deltaX * scrollFactor);
+            this._updateScrollButtonsHiddenState();
+          }
+        },
+
+        _down: function(e) {
+          // go one beat async to defeat IronMenuBehavior
+          // autorefocus-on-no-selection timeout
+          this.async(function() {
+            if (this._defaultFocusAsync) {
+              this.cancelAsync(this._defaultFocusAsync);
+              this._defaultFocusAsync = null;
+            }
+          }, 1);
+        },
+
+        _updateScrollButtonsHiddenState: function() {
+          var normalizedLeft =
+            this._scrollLeftToNormalizedLeft(this.$.tabsContainer.scrollLeft);
+
+          this._leftHidden = normalizedLeft <= 0;
+          this._rightHidden = normalizedLeft >= this._tabContainerScrollSize;
+        },
+
+        /**
+         * Normalizes a value returned by `scrollLeft`, which can be writing
+         * direction dependent, to its LTR equivalent.
+         */
+        _scrollLeftToNormalizedLeft: function(scrollLeft) {
+          if (this._getRTL()) {
+            var normalizedLeft = scrollLeft;
+            normalizedLeft *= RTL_POSITIVE_LEFT ? -1 : 1;
+            normalizedLeft += RTL_ZERO_RIGHT ? this._tabContainerScrollSize : 0;
+            return normalizedLeft;
+          } else {
+            return scrollLeft;
+          }
+        },
+
+        /**
+         * Converts normalized (LTR-like) `scrollLeft` values to the browser
+         * specific value based on the element's current directionality.
+         */
+        _normalizedLeftToScrollLeft: function(normalizedLeft) {
+          if (this._getRTL()) {
+            var scrollLeft = normalizedLeft;
+            scrollLeft -= RTL_ZERO_RIGHT ? this._tabContainerScrollSize : 0;
+            scrollLeft *= RTL_POSITIVE_LEFT ? -1 : 1;
+            return scrollLeft;
+          } else {
+            return normalizedLeft;
+          }
+        },
+
+        /**
+         * Scrolls to a normalized (LTR-like) `scrollLeft` position, regardless
+         * of the element's current directionality.
+         */
+        _scrollToNormalizedLeft: function(normalizedLeft) {
+          this.$.tabsContainer.scrollLeft = this._normalizedLeftToScrollLeft(normalizedLeft);
+          this._updateScrollButtonsHiddenState();
+        },
+
+        /**
+         * Adjusts `scrollLeft` by a relative amount, with positive values
+         * scrolling into view content hidden to the right (LTR-like),
+         * regardless of the element's current directionality.
+         */
+        _affectScroll: function(dx) {
+          this.$.tabsContainer.scrollLeft += (this._getRTL() && RTL_POSITIVE_LEFT ? -1 : 1) * dx;
+          this._updateScrollButtonsHiddenState();
+        },
+
+        _onLeftScrollButtonDown: function() {
+          this._scrollToLeft();
+          this._holdJob = setInterval(this._scrollToLeft.bind(this), this._holdDelay);
+        },
+
+        _onRightScrollButtonDown: function() {
+          this._scrollToRight();
+          this._holdJob = setInterval(this._scrollToRight.bind(this), this._holdDelay);
+        },
+
+        _onScrollButtonUp: function() {
+          clearInterval(this._holdJob);
+          this._holdJob = null;
+        },
+
+        _scrollToLeft: function() {
+          this._affectScroll(-this._step);
+        },
+
+        _scrollToRight: function() {
+          this._affectScroll(this._step);
+        },
+
+        _tabChanged: function(tab, old) {
+          if (!tab) {
+            // Remove the bar without animation.
+            this.$.selectionBar.classList.remove('expand');
+            this.$.selectionBar.classList.remove('contract');
+            this._positionBar(0, 0);
+            return;
+          }
+
+          var r = this.$.tabsContent.getBoundingClientRect();
+          var w = r.width;
+          var tabRect = tab.getBoundingClientRect();
+          var tabOffsetLeft = tabRect.left - r.left;
+
+          this._pos = {
+            width: this._calcPercent(tabRect.width, w),
+            left: this._calcPercent(tabOffsetLeft, w)
+          };
+
+          if (this.noSlide || old == null) {
+            // Position the bar without animation.
+            this.$.selectionBar.classList.remove('expand');
+            this.$.selectionBar.classList.remove('contract');
+            this._positionBar(this._pos.width, this._pos.left);
+          } else {
+            var oldRect = old.getBoundingClientRect();
+            var oldIndex = this.items.indexOf(old);
+            var index = this.items.indexOf(tab);
+            var m = 5;
+
+            // bar animation: expand
+            this.$.selectionBar.classList.add('expand');
+
+            var moveRight = oldIndex < index;
+            var isRTL = this._getRTL();
+            if (isRTL) {
+              moveRight = !moveRight;
+            }
+
+            if (moveRight) {
+              this._positionBar(this._calcPercent(tabRect.left + tabRect.width - oldRect.left, w) - m,
+                  this._left);
+            } else {
+              this._positionBar(this._calcPercent(oldRect.left + oldRect.width - tabRect.left, w) - m,
+                  this._calcPercent(tabOffsetLeft, w) + m);
+            }
+          }
+
+          if (this.scrollable) {
+            this._scrollToSelectedIfNeeded(tabRect.width, tabOffsetLeft);
+          }
+
+          this._updateScrollButtonsHiddenState();
+        },
+
+        _scrollToSelectedIfNeeded: function(tabWidth, tabOffsetLeft) {
+          var containerRect = this.$.tabsContainer.getBoundingClientRect();
+          var tabRect = this.selectedItem.getBoundingClientRect();
+          var normalizedLeft =
+            this._scrollLeftToNormalizedLeft(this.$.tabsContainer.scrollLeft);
+
+          if (tabOffsetLeft < normalizedLeft) {
+            this._scrollToNormalizedLeft(tabOffsetLeft);
+          } else if (normalizedLeft + containerRect.width < tabOffsetLeft + tabWidth) {
+            this._scrollToNormalizedLeft(tabOffsetLeft + tabWidth - containerRect.width);
+          }
+        },
+
+        _calcPercent: function(w, w0) {
+          return 100 * w / w0;
+        },
+
+        _positionBar: function(width, left) {
+          width = width || 0;
+          left = left || 0;
+
+          this._width = width;
+          this._left = left;
+          this.transform(
+              'translateX(' + left + '%) scaleX(' + (width / 100) + ')',
+              this.$.selectionBar);
+        },
+
+        _onBarTransitionEnd: function(e) {
+          var cl = this.$.selectionBar.classList;
+          // bar animation: expand -> contract
+          if (cl.contains('expand')) {
+            cl.remove('expand');
+            cl.add('contract');
+            this._positionBar(this._pos.width, this._pos.left);
+          // bar animation done
+          } else if (cl.contains('contract')) {
+            cl.remove('contract');
           }
         }
-      },
-
-      _calcPercent: function(w, w0) {
-        return 100 * w / w0;
-      },
-
-      _positionBar: function(width, left) {
-        width = width || 0;
-        left = left || 0;
-
-        this._width = width;
-        this._left = left;
-        this.transform(
-            'translateX(' + left + '%) scaleX(' + (width / 100) + ')',
-            this.$.selectionBar);
-      },
-
-      _onBarTransitionEnd: function(e) {
-        var cl = this.$.selectionBar.classList;
-        // bar animation: expand -> contract
-        if (cl.contains('expand')) {
-          cl.remove('expand');
-          cl.add('contract');
-          this._positionBar(this._pos.width, this._pos.left);
-        // bar animation done
-        } else if (cl.contains('contract')) {
-          cl.remove('contract');
-        }
-      }
-    });
+      });
+    })();
   </script>
 </dom-module>

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -612,17 +612,21 @@ Custom property | Description | Default
           this._positionBar(this._pos.width, this._pos.left);
         } else {
           var oldRect = old.getBoundingClientRect();
-          var oldOffsetLeft = oldRect.left - scrollContentRect.left;
-          var left = Math.min(tabRect.left, oldRect.left);
-          var right = Math.max(tabRect.right, oldRect.right);
-          var expandedPadding = 0.05;
-          var expandedWidth = (1 - 2 * expandedPadding) * (right - left);
-          var expandedLeft = (left - scrollContentRect.left) + expandedPadding * (right - left);
-          var expandedWidthPercent = this._calcPercent(expandedWidth, scrollContentWidth);
-          var expandedLeftPercent = this._calcPercent(expandedLeft, scrollContentWidth);
+
+          var minLeft = Math.min(tabRect.left, oldRect.left);
+          var maxRight = Math.max(tabRect.right, oldRect.right);
+          var totalWidth = maxRight - minLeft;
+
+          // The padding around both sides of the selection bar in the
+          // mid-transition expanded state, in units of `totalWidth`.
+          var padding = 0.05;
+          var targetWidth = (1 - 2 * padding) * totalWidth;
+          var targetLeft = (minLeft - scrollContentRect.left) + padding * totalWidth;
 
           this.$.selectionBar.classList.add('expand');
-          this._positionBar(expandedWidthPercent, expandedLeftPercent);
+          var targetWidthPercent = this._calcPercent(targetWidth, scrollContentWidth);
+          var targetLeftPercent = this._calcPercent(targetLeft, scrollContentWidth);
+          this._positionBar(targetWidthPercent, targetLeftPercent);
         }
 
         if (this.scrollable) {

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -594,14 +594,15 @@ Custom property | Description | Default
           return;
         }
 
-        var r = this.$.tabsContent.getBoundingClientRect();
-        var w = r.width;
+        var scrollContentRect = this.$.tabsContent.getBoundingClientRect();
+        var scrollContentWidth = scrollContentRect.width;
         var tabRect = tab.getBoundingClientRect();
-        var tabOffsetLeft = tabRect.left - r.left;
+        var tabOffsetLeft = tabRect.left - scrollContentRect.left;
 
+        // The final position of the bar, below the newly selected tab.
         this._pos = {
-          width: this._calcPercent(tabRect.width, w),
-          left: this._calcPercent(tabOffsetLeft, w)
+          width: this._calcPercent(tabRect.width, scrollContentWidth),
+          left: this._calcPercent(tabOffsetLeft, scrollContentWidth)
         };
 
         if (this.noSlide || old == null) {
@@ -611,26 +612,17 @@ Custom property | Description | Default
           this._positionBar(this._pos.width, this._pos.left);
         } else {
           var oldRect = old.getBoundingClientRect();
-          var oldIndex = this.items.indexOf(old);
-          var index = this.items.indexOf(tab);
-          var m = 5;
+          var oldOffsetLeft = oldRect.left - scrollContentRect.left;
+          var left = Math.min(tabRect.left, oldRect.left);
+          var right = Math.max(tabRect.right, oldRect.right);
+          var expandedPadding = 0.05;
+          var expandedWidth = (1 - 2 * expandedPadding) * (right - left);
+          var expandedLeft = (left - scrollContentRect.left) + expandedPadding * (right - left);
+          var expandedWidthPercent = this._calcPercent(expandedWidth, scrollContentWidth);
+          var expandedLeftPercent = this._calcPercent(expandedLeft, scrollContentWidth);
 
-          // bar animation: expand
           this.$.selectionBar.classList.add('expand');
-
-          var moveRight = oldIndex < index;
-          var isRTL = this.__getRTL();
-          if (isRTL) {
-            moveRight = !moveRight;
-          }
-
-          if (moveRight) {
-            this._positionBar(this._calcPercent(tabRect.left + tabRect.width - oldRect.left, w) - m,
-                this._left);
-          } else {
-            this._positionBar(this._calcPercent(oldRect.left + oldRect.width - tabRect.left, w) - m,
-                this._calcPercent(tabOffsetLeft, w) + m);
-          }
+          this._positionBar(expandedWidthPercent, expandedLeftPercent);
         }
 
         if (this.scrollable) {
@@ -720,7 +712,6 @@ Custom property | Description | Default
         if (__rtlBehavior.zeroRight === undefined) {
           this.__checkRTLBehavior();
         }
-
         return __rtlBehavior.zeroRight;
       },
 
@@ -733,7 +724,6 @@ Custom property | Description | Default
         if (__rtlBehavior.positiveLeft === undefined) {
           this.__checkRTLBehavior();
         }
-
         return __rtlBehavior.positiveLeft;
       },
 

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -236,7 +236,9 @@ Custom property | Description | Default
       // (As opposed to LTR, where `scrollLeft` is zero when when the left edge
       // of the scrollable area is aligned with the left edge of its overflowing
       // content.)
-      var RTL_ZERO_RIGHT = false;
+      // This variable is determined and set in `__checkRTLBehavior` the first
+      // time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
+      var RTL_ZERO_RIGHT = undefined;
 
       // True if, when an element has RTL directionality, positive changes to
       // `scrollLeft` cause the scrollable area to show content that is further
@@ -244,70 +246,9 @@ Custom property | Description | Default
       // (As opposed to LTR, where positive changes to `scrollLeft` cause the
       // scrollable area to show overflowing content that is further to the
       // right.)
-      var RTL_POSITIVE_LEFT = false;
-
-      var SCROLLBAR_HEIGHT = 16;
-
-      (function() {
-        function testRTLScrollLeftBehavior() {
-          var outer = document.createElement('div');
-          outer.setAttribute('dir', 'rtl');
-          outer.style.position = 'absolute';
-          outer.style.width = '50px';
-          outer.style.height = '50px';
-          outer.style.overflow = 'hidden';
-
-          var inner = document.createElement('div');
-          inner.style.width = '100px';
-          inner.style.height = '100px';
-          outer.appendChild(inner);
-
-          document.body.appendChild(outer);
-
-          // Is this container's non-zero-edge alignment represented by a
-          // positive or negative value? (Are we able to scroll to a negative
-          // value when the only overflowing content is positioned positively?)
-          outer.scrollLeft = -10000;
-          var fullScrollNegative = outer.scrollLeft < 0;
-
-          // Are the right edges of the container and its overflowing content
-          // aligned when `scrollLeft` is zero? (The overflowing content is
-          // larger than the container, so only one set of edges can be
-          // aligned.)
-          outer.scrollLeft = 0;
-          var innerStartRect = inner.getBoundingClientRect();
-          var outerStartRect = outer.getBoundingClientRect();
-          RTL_ZERO_RIGHT = innerStartRect.right === outerStartRect.right;
-
-          // Scroll to the end of the scrollable area in the available non-zero
-          // direction.
-          outer.scrollLeft += (fullScrollNegative ? -1 : 1) * 10000;
-          var innerEndRect = inner.getBoundingClientRect();
-
-          // If the change made to `scrollLeft` and the amount by which its
-          // overflowing content's bounding box moved have matching signs, then
-          // left is the positive direction.
-          var contentMovementNegative = innerEndRect.left < innerStartRect.left;
-          RTL_POSITIVE_LEFT = fullScrollNegative === contentMovementNegative;
-
-          outer.style.overflow = 'scroll';
-          SCROLLBAR_HEIGHT = outer.offsetHeight - outer.clientHeight;
-
-          document.body.removeChild(outer);
-        };
-
-        // Wait for the load event if necessary, otherwise
-        // `getBoundingClientRect` will only return rectangles with all values
-        // set to zero.
-        if (document.readyState === 'complete') {
-          testRTLScrollLeftBehavior();
-        } else {
-          window.addEventListener('load', function onLoad() {
-            window.removeEventListener('load', onLoad);
-            testRTLScrollLeftBehavior();
-          });
-        }
-      })();
+      // This variable is determined and set in `__checkRTLBehavior` the first
+      // time `__rtlZeroRight` or `__rtlPositiveLeft` is read.
+      var RTL_POSITIVE_LEFT = undefined;
 
       Polymer({
         is: 'paper-tabs',
@@ -649,8 +590,8 @@ Custom property | Description | Default
         _scrollLeftToNormalizedLeft: function(scrollLeft) {
           if (this._getRTL()) {
             var normalizedLeft = scrollLeft;
-            normalizedLeft *= RTL_POSITIVE_LEFT ? -1 : 1;
-            normalizedLeft += RTL_ZERO_RIGHT ? this._tabContainerScrollSize : 0;
+            normalizedLeft *= this.__rtlPositiveLeft ? -1 : 1;
+            normalizedLeft += this.__rtlZeroRight ? this._tabContainerScrollSize : 0;
             return normalizedLeft;
           } else {
             return scrollLeft;
@@ -664,8 +605,8 @@ Custom property | Description | Default
         _normalizedLeftToScrollLeft: function(normalizedLeft) {
           if (this._getRTL()) {
             var scrollLeft = normalizedLeft;
-            scrollLeft -= RTL_ZERO_RIGHT ? this._tabContainerScrollSize : 0;
-            scrollLeft *= RTL_POSITIVE_LEFT ? -1 : 1;
+            scrollLeft -= this.__rtlZeroRight ? this._tabContainerScrollSize : 0;
+            scrollLeft *= this.__rtlPositiveLeft ? -1 : 1;
             return scrollLeft;
           } else {
             return normalizedLeft;
@@ -687,7 +628,7 @@ Custom property | Description | Default
          * regardless of the element's current directionality.
          */
         _affectScroll: function(dx) {
-          this.$.tabsContainer.scrollLeft += (this._getRTL() && RTL_POSITIVE_LEFT ? -1 : 1) * dx;
+          this.$.tabsContainer.scrollLeft += (this._getRTL() && this.__rtlPositiveLeft ? -1 : 1) * dx;
           this._updateScrollButtonsHiddenState();
         },
 
@@ -808,7 +749,67 @@ Custom property | Description | Default
           } else if (cl.contains('contract')) {
             cl.remove('contract');
           }
-        }
+        },
+
+        get __rtlZeroRight() {
+          if (RTL_ZERO_RIGHT === undefined) {
+            this.__checkRTLBehavior();
+          }
+
+          return RTL_ZERO_RIGHT;
+        },
+
+        get __rtlPositiveLeft() {
+          if (RTL_POSITIVE_LEFT === undefined) {
+            this.__checkRTLBehavior();
+          }
+
+          return RTL_POSITIVE_LEFT;
+        },
+
+        __checkRTLBehavior: function() {
+          var outer = document.createElement('div');
+          outer.setAttribute('dir', 'rtl');
+          outer.style.position = 'absolute';
+          outer.style.width = '50px';
+          outer.style.height = '50px';
+          outer.style.overflow = 'hidden';
+
+          var inner = document.createElement('div');
+          inner.style.width = '100px';
+          inner.style.height = '100px';
+          outer.appendChild(inner);
+
+          document.body.appendChild(outer);
+
+          // Is this container's non-zero-edge alignment represented by a
+          // positive or negative value? (Are we able to scroll to a negative
+          // value when the only overflowing content is positioned positively?)
+          outer.scrollLeft = -10000;
+          var fullScrollNegative = outer.scrollLeft < 0;
+
+          // Are the right edges of the container and its overflowing content
+          // aligned when `scrollLeft` is zero? (The overflowing content is
+          // larger than the container, so only one set of edges can be
+          // aligned.)
+          outer.scrollLeft = 0;
+          var innerStartRect = inner.getBoundingClientRect();
+          var outerStartRect = outer.getBoundingClientRect();
+          RTL_ZERO_RIGHT = innerStartRect.right === outerStartRect.right;
+
+          // Scroll to the end of the scrollable area in the available non-zero
+          // direction.
+          outer.scrollLeft += (fullScrollNegative ? -1 : 1) * 10000;
+          var innerEndRect = inner.getBoundingClientRect();
+
+          // If the change made to `scrollLeft` and the amount by which its
+          // overflowing content's bounding box moved have matching signs, then
+          // left is the positive direction.
+          var contentMovementNegative = innerEndRect.left < innerStartRect.left;
+          RTL_POSITIVE_LEFT = fullScrollNegative === contentMovementNegative;
+
+          document.body.removeChild(outer);
+        },
       });
     })();
   </script>

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -216,7 +216,7 @@ Custom property | Description | Default
 
     <paper-icon-button icon="paper-tabs:chevron-left" class$="[[_computeScrollButtonClass(_leftHidden, scrollable, hideScrollButtons)]]" on-up="_onScrollButtonUp" on-down="_onLeftScrollButtonDown" tabindex="-1"></paper-icon-button>
 
-    <div id="tabsContainer" on-track="_onTrack" on-wheel="_onWheel" on-down="_down">
+    <div id="tabsContainer" on-track="_scroll" on-wheel="_onWheel" on-down="_down">
       <div id="tabsContent" class$="[[_computeTabsContentClass(scrollable, fitContainer)]]">
         <div id="selectionBar" class$="[[_computeSelectionBarClass(noBar, alignBottom)]]"
             on-transitionend="_onBarTransitionEnd"></div>
@@ -591,12 +591,13 @@ Custom property | Description | Default
           return this._cachedRTL !== undefined ? this._cachedRTL : this._isRTL;
         },
 
-        _onTrack: function(e, detail) {
-          if (!this.scrollable) return;
-
-          if (detail && detail.ddx !== undefined) {
-            this._affectScroll(-detail.ddx);
+        _scroll: function(e, detail) {
+          if (!this.scrollable) {
+            return;
           }
+
+          var ddx = (detail && -detail.ddx) || 0;
+          this._affectScroll(ddx);
         },
 
         _onWheel: function(e) {

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -126,10 +126,26 @@ Custom property | Description | Default
         position: relative;
         height: 100%;
         white-space: nowrap;
-        overflow: hidden;
+        /*
+        Fall back to scrollbars; `overflow` can't be `hidden` because it
+        disables native scrolling.
+        */
+        overflow: scroll;
+        /* Hide scrollbars in Firefox. */
+        overflow: -moz-scrollbars-none;
+        /* Hide scrollbars in Edge and IE. */
+        -ms-overflow-style: none;
+        /* Enable scrolling inertia in mobile Safari. */
         -webkit-overflow-scrolling: touch;
         @apply(--layout-flex-auto);
         @apply(--paper-tabs-container);
+      }
+
+      /* Hide scrollbars in Chrome and Safari. */
+      #tabsContainer::-webkit-scrollbar {
+        width: 0px;
+        height: 0px;
+        background: transparent;
       }
 
       #tabsContent {
@@ -525,26 +541,7 @@ Custom property | Description | Default
       },
 
       _onWheel: function(e) {
-        if (e.deltaX === 0) return;
-
-        var scrollFactor = 0;
-        switch (e.deltaMode) {
-          case WheelEvent.DOM_DELTA_PIXEL:
-            scrollFactor = 1;
-          break;
-          case WheelEvent.DOM_DELTA_LINE:
-            scrollFactor = parseFloat(getComputedStyle(this).fontSize);
-          break;
-          case WheelEvent.DOM_DELTA_PAGE:
-            scrollFactor = this.$.tabsContainer.getBoundingClientRect().width;
-          break;
-        }
-
-        if (scrollFactor !== 0) {
-          e.preventDefault();
-          this._affectScroll(e.deltaX * scrollFactor);
-          this.__updateScrollButtonsHiddenState();
-        }
+        this.__updateScrollButtonsHiddenState();
       },
 
       _down: function(e) {

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -232,7 +232,7 @@ Custom property | Description | Default
 
     <paper-icon-button icon="paper-tabs:chevron-left" class$="[[_computeScrollButtonClass(_leftHidden, scrollable, hideScrollButtons)]]" on-up="_onScrollButtonUp" on-down="_onLeftScrollButtonDown" tabindex="-1"></paper-icon-button>
 
-    <div id="tabsContainer" on-track="_scroll" on-wheel="_onWheel" on-down="_down">
+    <div id="tabsContainer" on-track="_scroll" on-scroll="_onScroll" on-down="_down">
       <div id="tabsContent" class$="[[_computeTabsContentClass(scrollable, fitContainer)]]">
         <div id="selectionBar" class$="[[_computeSelectionBarClass(noBar, alignBottom)]]"
             on-transitionend="_onBarTransitionEnd"></div>
@@ -540,7 +540,7 @@ Custom property | Description | Default
         this._affectScroll(ddx);
       },
 
-      _onWheel: function(e) {
+      _onScroll: function(e) {
         this.__updateScrollButtonsHiddenState();
       },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -44,6 +44,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="scrollable">
+      <template>
+        <paper-tabs scrollable>
+          <paper-tab>NUMBER ONE ITEM</paper-tab>
+          <paper-tab>ITEM TWO</paper-tab>
+          <paper-tab>THE THIRD ITEM</paper-tab>
+          <paper-tab>THE ITEM FOUR</paper-tab>
+          <paper-tab>FIFTH</paper-tab>
+          <paper-tab>THE SIXTH TAB</paper-tab>
+          <paper-tab>NUMBER SEVEN</paper-tab>
+          <paper-tab>EIGHT</paper-tab>
+          <paper-tab>NUMBER NINE</paper-tab>
+          <paper-tab>THE TENTH</paper-tab>
+          <paper-tab>THE ITEM ELEVEN</paper-tab>
+          <paper-tab>TWELFTH ITEM</paper-tab>
+        </paper-tabs>
+      </template>
+    </test-fixture>
+
     <script>
 
       function ensureDocumentHasFocus() {
@@ -386,9 +405,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               });
             });
           });
+        });
+
+      suite('scrollable', function() {
+        function generateScrollableTestSuite(dir) {
+          return function() {
+            var tabs;
+            var tabScrollContainer;
+
+            setup(function () {
+              tabs = fixture('scrollable');
+              tabs.setAttribute('dir', dir);
+              tabs.style.width = '500px';
+              tabScrollContainer = tabs.$.tabsContainer;
+            });
+
+            test("The test tab container width is smaller than the scroll area.", function() {
+              var tabScrollContainerRect = tabScrollContainer.getBoundingClientRect();
+              assert.isTrue(tabScrollContainer.scrollWidth > tabScrollContainerRect.width);
+            });
+
+            function assertItemVisibleWithinTolerance(item, tolerancePx) {
+              var scrollContainerRect = tabScrollContainer.getBoundingClientRect();
+              var itemRect = item.getBoundingClientRect();
+              assert.isTrue((scrollContainerRect.left - itemRect.left) < tolerancePx);
+              assert.isTrue((itemRect.right - scrollContainerRect.right) < tolerancePx);
+            }
+
+            test("When an item is selected, that item is visible.", function() {
+              for (var i = 0; i < tabs.items.length; i++) {
+                tabs.selected = i;
+                assertItemVisibleWithinTolerance(tabs.items[i], 1);
+              }
+              for (var i = tabs.items.length - 1; i >= 0; i--) {
+                tabs.selected = i;
+                assertItemVisibleWithinTolerance(tabs.items[i], 1);
+              }
+            });
+          };
+        }
+
+        suite('LTR', generateScrollableTestSuite('ltr'));
+        suite('RTL', generateScrollableTestSuite('rtl'));
       });
 
     </script>
-
   </body>
 </html>


### PR DESCRIPTION
(Fixes #129. Fixes #203. [?w=1](https://github.com/PolymerElements/paper-tabs/pull/142/files?w=1))
