### PR TITLE
Fixes #141. Click anchors on enter and space

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -170,7 +170,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <h3>
         Use the <code>link</code> attribute when a <code>paper-tab</code>
-        contains a link. The link will fill the entire tab.
+        contains a link. The link will fill the entire tab. <code>paper-tabs</code>
+        implements its own tabindexing and keyboard focus patterns so an anchor
+        placed inside should set <code>tabindex="-1"</code>.
       </h3>
       <demo-snippet>
         <template>
@@ -185,9 +187,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </style>
 
           <paper-tabs selected="0">
-            <paper-tab link><a href="#item1">ITEM ONE</a></paper-tab>
-            <paper-tab link><a href="#item2">ITEM TWO</a></paper-tab>
-            <paper-tab link><a href="#item3">ITEM THREE</a></paper-tab>
+            <paper-tab link>
+              <a href="#item1" tabindex="-1">ITEM ONE</a>
+            </paper-tab>
+            <paper-tab link>
+              <a href="#item2" tabindex="-1">ITEM TWO</a>
+            </paper-tab>
+            <paper-tab link>
+              <a href="#item3" tabindex="-1">ITEM THREE</a>
+            </paper-tab>
           </paper-tabs>
         </template>
       </demo-snippet>

--- a/paper-tab.html
+++ b/paper-tab.html
@@ -56,7 +56,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         overflow: hidden;
         cursor: pointer;
         vertical-align: middle;
-        
+
         @apply(--paper-font-common-base);
         @apply(--paper-tab);
       }
@@ -117,12 +117,27 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         Polymer.PaperRippleBehavior
       ],
 
+      properties: {
+
+        /**
+         * If true, the tab will forward keyboard clicks (enter/space) to
+         * the first anchor element found in its descendants
+         */
+        link: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true
+        }
+
+      },
+
       hostAttributes: {
         role: 'tab'
       },
 
       listeners: {
-        down: '_updateNoink'
+        down: '_updateNoink',
+        tap: '_onTap'
       },
 
       attached: function() {
@@ -136,7 +151,26 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
       _updateNoink: function() {
         this.noink = !!this.noink || !!this._parentNoink;
+      },
+
+      _onTap: function(event) {
+        if (this.link) {
+          var anchor = this.queryEffectiveChildren('a');
+
+          if (!anchor) {
+            return;
+          }
+
+          // Don't get stuck in a loop delegating
+          // the listener from the child anchor
+          if (event.target === anchor) {
+            return;
+          }
+
+          anchor.click();
+        }
       }
+
     });
   </script>
 </dom-module>

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -54,7 +54,7 @@ between different views.
 
 
 To use links in tabs, add `link` attribute to `paper-tab` and put an `<a>`
-element in `paper-tab`.
+element in `paper-tab` with a `tabindex` of -1.
 
 Example:
 
@@ -68,13 +68,13 @@ Example:
 
 &lt;paper-tabs selected="0">
   &lt;paper-tab link>
-    &lt;a href="#link1" class="link">TAB ONE&lt;/a>
+    &lt;a href="#link1" class="link" tabindex="-1">TAB ONE&lt;/a>
   &lt;/paper-tab>
   &lt;paper-tab link>
-    &lt;a href="#link2" class="link">TAB TWO&lt;/a>
+    &lt;a href="#link2" class="link" tabindex="-1">TAB TWO&lt;/a>
   &lt;/paper-tab>
   &lt;paper-tab link>
-    &lt;a href="#link3" class="link">TAB THREE&lt;/a>
+    &lt;a href="#link3" class="link" tabindex="-1">TAB THREE&lt;/a>
   &lt;/paper-tab>
 &lt;/paper-tabs>
 </code></pre>

--- a/test/index.html
+++ b/test/index.html
@@ -19,11 +19,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       WCT.loadSuites([
         'basic.html',
         'attr-for-selected.html',
+        'links.html',
         'basic.html?dom=shadow',
-        'attr-for-selected.html?dom=shadow'
+        'attr-for-selected.html?dom=shadow',
+        'links.html?dom=shadow'
       ]);
     </script>
 
-  
+
 
 </body></html>

--- a/test/links.html
+++ b/test/links.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+  <head>
+
+    <title>paper-tabs-links</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../paper-tabs.html">
+    <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+
+  </head>
+  <body>
+
+    <test-fixture id="links">
+      <template>
+        <paper-tabs>
+          <paper-tab link><a href="#one" tabindex="-1">ONE</a></paper-tab>
+          <paper-tab link><a href="#two" tabindex="-1">TWO</a></paper-tab>
+          <paper-tab link><a href="#three" tabindex="-1">THREE</a></paper-tab>
+        </paper-tabs>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="not-links">
+      <template>
+        <paper-tabs>
+          <paper-tab><a href="#one" tabindex="-1">ONE</a></paper-tab>
+          <paper-tab><a href="#two" tabindex="-1">TWO</a></paper-tab>
+          <paper-tab><a href="#three" tabindex="-1">THREE</a></paper-tab>
+        </paper-tabs>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="not-first-child">
+      <template>
+        <paper-tabs>
+          <paper-tab>
+            <div>
+              <a href="#one" tabindex="-1">ONE</a>
+            </div>
+          </paper-tab>
+          <paper-tab>
+            <div>
+              <a href="#two" tabindex="-1">TWO</a>
+            </div>
+          </paper-tab>
+          <paper-tab>
+            <div>
+              <a href="#three" tabindex="-1">THREE</a>
+            </div>
+          </paper-tab>
+        </paper-tabs>
+      </template>
+    </test-fixture>
+
+    <script>
+
+      suite('links', function() {
+
+        suite('has link attribute', function() {
+
+          var tabs;
+          var tab, anchor;
+
+          setup(function () {
+            tabs = fixture('links');
+            tab = tabs.querySelectorAll('paper-tab')[1];
+            anchor = tab.querySelector('a');
+          });
+
+          test('pressing enter on tab causes anchor click', function(done) {
+            tab.addEventListener('click', function onTabClick(event) {
+              tab.removeEventListener('click', onTabClick);
+
+              expect(event.target).to.be.equal(anchor);
+              done();
+            });
+
+            MockInteractions.pressEnter(tab);
+          });
+
+          test('pressing space on tab causes anchor click', function(done) {
+            tab.addEventListener('click', function onTabClick(event) {
+              tab.removeEventListener('click', onTabClick);
+
+              expect(event.target).to.be.equal(anchor);
+              done();
+            });
+
+            MockInteractions.pressSpace(tab);
+          });
+
+        });
+
+        suite('does not have link attribute', function() {
+
+          var tabs;
+          var tab, anchor;
+
+          setup(function () {
+            tabs = fixture('not-links');
+            tab = tabs.querySelectorAll('paper-tab')[1];
+            anchor = tab.querySelector('a');
+          });
+
+          test('pressing enter on tab does not cause anchor click', function(done) {
+            tab.addEventListener('click', function onTabClick(event) {
+              tab.removeEventListener('click', onTabClick);
+
+              expect(event.target).to.not.equal(anchor);
+              expect(event.target).to.be.equal(tab);
+              done();
+            });
+
+            MockInteractions.pressEnter(tab);
+          });
+
+        });
+
+        suite('not first child', function() {
+
+          var tabs;
+          var tab, anchor;
+
+          setup(function () {
+            tabs = fixture('links');
+            tab = tabs.querySelectorAll('paper-tab')[1];
+            anchor = tab.querySelector('a');
+          });
+
+          test('pressing enter on tab causes anchor click', function(done) {
+            tab.addEventListener('click', function onTabClick(event) {
+              tab.removeEventListener('click', onTabClick);
+
+              expect(event.target).to.be.equal(anchor);
+              done();
+            });
+
+            MockInteractions.pressEnter(tab);
+          });
+
+        });
+
+      });
+
+    </script>
+
+  </body>
+</html>


### PR DESCRIPTION
When a user presses the enter or space key while focused on a paper-tab, if that tab has a `link` attribute it will call `click` on any anchor contained inside of it.