### PR TITLE
Use translateX instead of translate3d

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -609,7 +609,7 @@ Custom property | Description | Default
         this._width = width;
         this._left = left;
         this.transform(
-            'translate3d(' + left + '%, 0, 0) scaleX(' + (width / 100) + ')',
+            'translateX(' + left + '%) scaleX(' + (width / 100) + ')',
             this.$.selectionBar);
       },
 


### PR DESCRIPTION
Use translateX instead of translated3d to move the selection bar. This is preferable to avoid some bugs present in Chrome (such as https://bugs.chromium.org/p/chromium/issues/detail?id=449107).