### PR TITLE
Collapse chevron containers when not visible

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -174,6 +174,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </demo-snippet>
 
       <h3>
+        Arrow containers are collapsed when arrows are not required to be visible.
+      </h3>
+      <demo-snippet>
+        <template>
+          <div>
+            <paper-tabs selected="0" scrollable>
+              <paper-tab>NUMBER ONE ITEM</paper-tab>
+              <paper-tab>ITEM TWO</paper-tab>
+              <paper-tab>THE THIRD ITEM</paper-tab>
+              <paper-tab>THE ITEM FOUR</paper-tab>
+              <paper-tab>FIFTH</paper-tab>
+              <paper-tab>THE SIXTH TAB</paper-tab>
+              <paper-tab>NUMBER SEVEN</paper-tab>
+              <paper-tab>EIGHT</paper-tab>
+              <paper-tab>NUMBER NINE</paper-tab>
+              <paper-tab>THE TENTH</paper-tab>
+              <paper-tab>THE ITEM ELEVEN</paper-tab>
+              <paper-tab>TWELFTH ITEM</paper-tab>
+            </paper-tabs>
+            &nbsp;
+            <paper-tabs selected="0" scrollable collapse-scroll-buttons>
+              <paper-tab>NUMBER ONE ITEM</paper-tab>
+              <paper-tab>ITEM TWO</paper-tab>
+              <paper-tab>THE THIRD ITEM</paper-tab>
+              <paper-tab>THE ITEM FOUR</paper-tab>
+              <paper-tab>FIFTH</paper-tab>
+              <paper-tab>THE SIXTH TAB</paper-tab>
+              <paper-tab>NUMBER SEVEN</paper-tab>
+              <paper-tab>EIGHT</paper-tab>
+              <paper-tab>NUMBER NINE</paper-tab>
+              <paper-tab>THE TENTH</paper-tab>
+              <paper-tab>THE ITEM ELEVEN</paper-tab>
+              <paper-tab>TWELFTH ITEM</paper-tab>
+            </paper-tabs>
+          </div>
+        </template>
+      </demo-snippet>
+
+      <h3>
         Use the <code>align-bottom</code> attribute when your tabs are
         positioned below the content they control. The selection bar will be
         shown at the top of the tabs.

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -209,7 +209,7 @@ Custom property | Description | Default
       }
     </style>
 
-    <paper-icon-button icon="paper-tabs:chevron-left" class$="[[_computeScrollButtonClass(_leftHidden, scrollable, hideScrollButtons)]]" on-up="_onScrollButtonUp" on-down="_onLeftScrollButtonDown" tabindex="-1"></paper-icon-button>
+    <paper-icon-button icon="paper-tabs:chevron-left" class$="[[_computeScrollButtonClass(_leftHidden, scrollable, hideScrollButtons, collapseScrollButtons)]]" on-up="_onScrollButtonUp" on-down="_onLeftScrollButtonDown" tabindex="-1"></paper-icon-button>
 
     <div id="tabsContainer" on-track="_scroll" on-down="_down">
       <div id="tabsContent" class$="[[_computeTabsContentClass(scrollable, fitContainer)]]">
@@ -219,7 +219,7 @@ Custom property | Description | Default
       </div>
     </div>
 
-    <paper-icon-button icon="paper-tabs:chevron-right" class$="[[_computeScrollButtonClass(_rightHidden, scrollable, hideScrollButtons)]]" on-up="_onScrollButtonUp" on-down="_onRightScrollButtonDown" tabindex="-1"></paper-icon-button>
+    <paper-icon-button icon="paper-tabs:chevron-right" class$="[[_computeScrollButtonClass(_rightHidden, scrollable, hideScrollButtons, collapseScrollButtons)]]" on-up="_onScrollButtonUp" on-down="_onRightScrollButtonDown" tabindex="-1"></paper-icon-button>
 
   </template>
 

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -294,6 +294,14 @@ Custom property | Description | Default
         },
 
         /**
+         * If true, scroll buttons (left/right arrow) containers will be collapsed while hidden for scrollable tabs.
+         */
+        collapseScrollButtons: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
          * If true, the tabs are aligned to bottom (the selection bar appears at the top).
          */
         alignBottom: {
@@ -394,13 +402,18 @@ Custom property | Description | Default
         element.removeAttribute('noink');
       },
 
-      _computeScrollButtonClass: function(hideThisButton, scrollable, hideScrollButtons) {
+      _computeScrollButtonClass: function(hideThisButton, scrollable, hideScrollButtons, collapseScrollButtons) {
         if (!scrollable || hideScrollButtons) {
           return 'hidden';
         }
 
         if (hideThisButton) {
-          return 'not-visible';
+          if(collapseScrollButtons) {
+            return 'hidden';
+          }
+          else {
+            return 'not-visible';
+          }
         }
 
         return '';


### PR DESCRIPTION
Allows for arrow container collapse when not shown and not always hidden, to increase usable space in tabs container.
Added demo for arrow container collapse and relevant functionality.
Addresses #166 
