### PR TITLE
Provide a means to edit the layout styles of tabs more explicitly & easily

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -88,7 +88,8 @@ Custom property | Description | Default
 `--paper-tabs-selection-bar-color` | Color for the selection bar | `--paper-yellow-a100`
 `--paper-tabs-selection-bar` | Mixin applied to the selection bar | `{}`
 `--paper-tabs` | Mixin applied to the tabs | `{}`
-`--paper-tabs-content` | Mixin applied to the direct container of tabs | `{}`
+`--paper-tabs-content` | Mixin applied to the content container of tabs | `{}`
+`--paper-tabs-container` | Mixin applied to the layout container of tabs | `{}`
 
 @hero hero.svg
 @demo demo/index.html

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -127,7 +127,6 @@ Custom property | Description | Default
         height: 100%;
         white-space: nowrap;
         overflow: hidden;
-        display: flex;
         @apply(--layout-flex-auto);
         @apply(--paper-tabs-container);
       }

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -88,6 +88,7 @@ Custom property | Description | Default
 `--paper-tabs-selection-bar-color` | Color for the selection bar | `--paper-yellow-a100`
 `--paper-tabs-selection-bar` | Mixin applied to the selection bar | `{}`
 `--paper-tabs` | Mixin applied to the tabs | `{}`
+`--paper-tabs-content` | Mixin applied to the direct container of tabs | `{}`
 
 @hero hero.svg
 @demo demo/index.html
@@ -125,6 +126,7 @@ Custom property | Description | Default
         height: 100%;
         white-space: nowrap;
         overflow: hidden;
+        display: flex;
         @apply(--layout-flex-auto);
       }
 
@@ -133,6 +135,7 @@ Custom property | Description | Default
         -moz-flex-basis: auto;
         -ms-flex-basis: auto;
         flex-basis: auto;
+        @apply(--paper-tabs-content);
       }
 
       #tabsContent.scrollable {

--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -129,6 +129,7 @@ Custom property | Description | Default
         overflow: hidden;
         display: flex;
         @apply(--layout-flex-auto);
+        @apply(--paper-tabs-container);
       }
 
       #tabsContent {


### PR DESCRIPTION
## PR Goals
- Enable more easier handling of the alignment & styling of the direct container of tabs
- Be more consistent with the style hook provided by `paper-tab` to its container of the content slotted in (`--paper-tab-content`)

## Side-effects
- New `--paper-tabs-content` custom property set and its corresponding `@apply` hook
- The file is now 5 lines bigger.

## Estimated Review Time
- 5-10 minutes

## Recommended reviewers
@bicknellr?
