### PR TITLE
Hide buttons using `visibility` instead of `opacity`.

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -165,8 +165,7 @@ Custom property | Description | Default
       }
 
       .not-visible {
-        opacity: 0;
-        cursor: default;
+        visibility: hidden;
       }
 
       paper-icon-button {


### PR DESCRIPTION
Fixes #216 by hiding the buttons with `visibility: hidden;` instead of `opacity: 0;`.