### PR TITLE
Fix initial selected tab not visible

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -538,6 +538,9 @@ Custom property | Description | Default
           this.$.selectionBar.classList.remove('expand');
           this.$.selectionBar.classList.remove('contract');
           this._positionBar(this._pos.width, this._pos.left);
+          if (this.scrollable) {
+            this._scrollToSelectedIfNeeded(tabRect.width, tabOffsetLeft);
+          }
           return;
         }
 


### PR DESCRIPTION
If the tabs are scrollable and the initial selected tab is not visible (i.e. it is off to the right), it should be scrolled to automatically. At present, this is not the case, because `_scrollToSelectedIfNeeded()` is not called when there is no 'old' tab.