### PR TITLE
Add --paper-tab-content-focused mixin

### DIFF
--- a/paper-tab.js
+++ b/paper-tab.js
@@ -91,6 +91,8 @@ Polymer({
       :host(:focus) .tab-content {
         opacity: 1;
         font-weight: 700;
+
+        @apply --paper-tab-content-focused;
       }
 
       paper-ripple {

--- a/paper-tab.js
+++ b/paper-tab.js
@@ -38,6 +38,7 @@ Custom property | Description | Default
 `--paper-tab-ink` | Ink color | `--paper-yellow-a100`
 `--paper-tab` | Mixin applied to the tab | `{}`
 `--paper-tab-content` | Mixin applied to the tab content | `{}`
+`--paper-tab-content-focused` | Mixin applied to the tab content when the tab is focused | `{}`
 `--paper-tab-content-unselected` | Mixin applied to the tab content when the tab is not selected | `{}`
 
 This element applies the mixin `--paper-font-common-base` but does not import


### PR DESCRIPTION
.tab-content styles can be customized when it's in default state (using [--paper-tab-content](https://github.com/PolymerElements/paper-tabs/blob/6032a481a1769cc61dcce308f1b807db5aca9291/paper-tab.js#L82l)), unselected (using [--paper-tab-content-unselected](https://github.com/PolymerElements/paper-tabs/blob/6032a481a1769cc61dcce308f1b807db5aca9291/paper-tab.js#L88)), but not when it's [focused](https://github.com/PolymerElements/paper-tabs/blob/6032a481a1769cc61dcce308f1b807db5aca9291/paper-tab.js#L92).